### PR TITLE
Scicd 548 duplicate log entries

### DIFF
--- a/iuf
+++ b/iuf
@@ -100,24 +100,14 @@ def validate_stages(config):
     # Ensure that if a `sat bootprep` config was specified (and the stage
     # is being run) it exists.
     bp_config = config.args.get("bootprep_config_managed", None)
-    bp_managed = []
-    bp_management = []
-
     if bp_config and "managed-nodes-rollout" in local_stages:
-        for entry in bp_config:
-            if not os.path.exists(entry):
-                errors.append("--bootprep-config-managed-nodes {} was specified but could not be found".format(entry))
-            else:
-                bp_managed.append(read_yaml(entry))
+        if not os.path.exists(entry):
+            errors.append("--bootprep-config-managed-nodes {} was specified but could not be found".format(entry))
 
     bp_config = config.args.get("bootprep_config_management", None)
     if bp_config and "management-nodes-rollout" in local_stages:
-        for entry in bp_config:
-            # print('ncn',bp_config)
-            if not os.path.exists(entry):
-                errors.append("--bootprep-config-management-nodes {} was specified but could not be found".format(entry))
-            else:
-                bp_management.append(read_yaml(entry))
+        if not os.path.exists(bp_config):
+            errors.append(f"--bootprep-config-management-nodes {bp_config} was specified but could not be found")
 
     if errors:
         install_logger.error("Problems were encountered:")
@@ -391,14 +381,14 @@ def main():
     bpc_help = formatted("""
     List of `sat bootprep` config files for non-mgmt nodes (compute, UAN).""")
 
-    install_sp.add_argument("-bc", "--bootprep-config-managed", action="store", nargs='+',
+    install_sp.add_argument("-bc", "--bootprep-config-managed", action="store",
         #default = ['../vcs/bootprep/compute-and-uan-bootprep.yaml'],
         help=bpc_help)
 
     bpc_help = formatted("""
     List of `sat bootprep` config files for management NCN nodes.""")
 
-    install_sp.add_argument("-bm", "--bootprep-config-management", action="store", nargs='+',
+    install_sp.add_argument("-bm", "--bootprep-config-management", action="store",
         #default = ['../vcs/bootprep/management-bootprep.yaml'],
         help=bpc_help)
 

--- a/iuf
+++ b/iuf
@@ -101,7 +101,7 @@ def validate_stages(config):
     # is being run) it exists.
     bp_config = config.args.get("bootprep_config_managed", None)
     if bp_config and "managed-nodes-rollout" in local_stages:
-        if not os.path.exists(entry):
+        if not os.path.exists(bp_config):
             errors.append("--bootprep-config-managed-nodes {} was specified but could not be found".format(entry))
 
     bp_config = config.args.get("bootprep_config_management", None)

--- a/lib/Activity.py
+++ b/lib/Activity.py
@@ -390,7 +390,7 @@ class Activity():
                         if not phases[name]["finishedAt"]:
                             if display:
                                 status = phases[name]["status"]
-                                if status == "Failed":
+                                if status == "Failed" or status == "Error":
                                     config.logger.error(f"    FINISHED PHASE: {dname} [{status}]")
                                 if status == "Omitted":
                                     config.logger.warning(f"  FINISHED PHASE: {dname} [{status}]")
@@ -447,7 +447,7 @@ class Activity():
 
     def get_workflow(self, config, workflow):
         try:
-            wf = config.connection.run("argo -n argo get {workflow} -o yaml".format(workflow=workflow))
+            wf = config.connection.run("kubectl -n argo get Workflow/{workflow} -o yaml".format(workflow=workflow))
         except Exception as e:
             config.logger.error(f"Unable to get workflow {workflow}: {e}")
             sys.exit(1)

--- a/lib/PodLogs.py
+++ b/lib/PodLogs.py
@@ -70,7 +70,7 @@ def generate_query(pod, container="", namespace=""):
 class PodLogs():
     def __init__(self, config_param, wfid):
         log_dir = config_param.args.get("log_dir")
-        self._log_dir = os.path.join(log_dir, config_param.timestamp, "pod_logs")
+        self._log_dir = os.path.join(log_dir, config_param.timestamp, "argo_logs")
         os.makedirs(self._log_dir, exist_ok=True)
         self._running = []
         self._logs = []

--- a/lib/SiteConfig.py
+++ b/lib/SiteConfig.py
@@ -70,8 +70,8 @@ class SiteConfig():
         self.session_vars = {}
         self.pre_rendered = {}
         self.rendered = {}
-        self.bp_managed = []
-        self.bp_management = []
+        self.bp_managed = ""
+        self.bp_management = ""
         self.product_catalog = {}
         self.mask_recipe_prods = []
         self.state_dir = config.args.get("state_dir")
@@ -108,9 +108,9 @@ class SiteConfig():
                 if not self.recipe_vars:
                     self.recipe_vars = read_yaml(rv_loc)
                 if os.path.exists(managed_loc):
-                    self.bp_managed.append(read_yaml(managed_loc))
+                    self.bp_managed = read_yaml(managed_loc)
                 if os.path.exists(management_loc):
-                    self.bp_management.append(read_yaml(management_loc))
+                    self.bp_management = read_yaml(management_loc)
             elif self.bpcd:
                 errors.append("The `-bpcd/--bootprep-config-dir {}` was specified but could not be found".format(self.bpcd))
 


### PR DESCRIPTION
## Summary and Scope

************************************
SCICD-548: Remove duplicate log entries
************************************
The log entries were of the form:
LOG FILE FOR start-operation: argo/johnn-230119-iupg2-process-media-m7vvp/johnn-230119-iupg2-process-media-m7vvp-3

Code-wise, the message looks something like:
LOG FILE FOR ${dname}: {s3}
Keep a record of the "{dname}: {s3}" combinations, so that no log file is
printed twice.

Also, in lib/PodLogs.py, change the name of the base directory for the pod
logs from "pod_logs" to "argo_logs", since it's more accurate.

************************************
SCICD-552: Use 1 Bootprep File for Managed/Management
************************************
The --bootprep-config-managed and --bootprep-config-management options
should only take one argument.  This simplifies the sat usage.  At some point
after Alice, we may revisit the multiple bootprep files.

## Issues and Related PRs
* Resolves:
 -- https://jira-pro.its.hpecorp.net:8443/browse/SCICD-548
 -- https://jira-pro.its.hpecorp.net:8443/browse/SCICD-552


## Testing

_List the environments in which these changes were tested._

### Tested on:
frigg