### PR TITLE
SCICD-587: Unnecessary Bootprep/VCS Requirements

### DIFF
--- a/iuf
+++ b/iuf
@@ -87,11 +87,11 @@ def validate_stages(config):
             errors.append("`--concurrency` requires a positive integer argument.")
 
     # Check if any of the stages requiring site-vars, etc are being called.
-    # Note that they aren't strictly required in process-media, but all
+    # Note that they aren't strictly required in deliver-product, but all
     # the variables are resolved in that stage.  Further error-checking
     # related to this is done in SiteConfig.
-    if any(stage in local_stages for stage in ["process-media",
-        "update-vcs-config", "update-cfs-config", "management-nodes-rollout"]):
+    if any(stage in local_stages for stage in ["update-vcs-config",
+        "update-cfs-config", "management-nodes-rollout"]):
         if not (config.args.get("site_vars", None) or config.args.get("bootprep_config_dir", None) \
             or config.args.get("recipe_vars", None)):
             errors.append("bootprep or vcs stages were called, but none of "
@@ -418,24 +418,29 @@ def main():
         help=argparse.SUPPRESS)
 
     install_sp.add_argument("-bc", "--bootprep-config-managed", action="store",
-        help="""List of `sat bootprep` config files for managed (compute and
-        application) nodes.""")
+        help="""`sat bootprep` config file for managed (compute and
+        application) nodes.  Note the path is relative to $PWD, unless an
+        absolute path is specified.""")
 
     install_sp.add_argument("-bm", "--bootprep-config-management", action="store",
-        help="""List of `sat bootprep` config files for management NCNs.""")
+        help="""`sat bootprep` config file for management NCNs.  Note the
+        path is relative to $PWD, unless an absolute path is specified.""")
 
     install_sp.add_argument("-bpcd", "--bootprep-config-dir", action="store",
-        help="""Directory containing HPE `product_vars.yaml` and `sat bootprep` configuration files. The expected content is:
-        $(BOOTPREP_CONFIG_DIR)/product_vars.yaml
-        $(BOOTPREP_CONFIG_DIR)/bootprep/compute-and-uan-bootprep.yaml
-        $(BOOTPREP_CONFIG_DIR)/bootprep/management-bootprep.yaml""")
+        help="""Directory containing HPE `product_vars.yaml` and
+        `sat bootprep` configuration files. The expected content is:
+            $(BOOTPREP_CONFIG_DIR)/product_vars.yaml
+            $(BOOTPREP_CONFIG_DIR)/bootprep/compute-and-uan-bootprep.yaml
+            $(BOOTPREP_CONFIG_DIR)/bootprep/management-bootprep.yaml
+        Note the path is relative to $PWD, unless an absolute path is specified.""")
 
     install_sp.add_argument("-rv", "--recipe-vars", action="store",
         help="""Path to a recipe variables YAML file. HPE provides the `product_vars.yaml` recipe variables file with each release.""")
 
     install_sp.add_argument("-sv", "--site-vars", action="store", default=False,
         help="""Path to a site variables YAML file. This file allows the user to override values defined in
-        the recipe variables YAML file. Defaults to ${RBD_BASE_DIR}/${IUF_ACTIVITY}/site_vars.yaml.""")
+        the recipe variables YAML file. Defaults to ${RBD_BASE_DIR}/${IUF_ACTIVITY}/site_vars.yaml.
+        Note the path is relative to $PWD, unless an absolute path is specified.""")
 
     install_sp.add_argument("-mrs", "--managed-rollout-strategy", action="store",
         choices=["reboot", "stage"],
@@ -444,7 +449,7 @@ def main():
         'stage' (set up nodes to reboot into new image after next WLM job). Defaults to 'stage'.""")
 
     install_sp.add_argument("-cmrp", "--concurrent-management-rollout-percentage",
-        action="store", default=20,
+        action="store", default=20, type=int,
         help="""Limit the number of management nodes that roll out
         concurrently based on the percentage specified. Must be an integer
         between 1-100. Defaults to 20 (percent).""")

--- a/lib/Activity.py
+++ b/lib/Activity.py
@@ -588,7 +588,8 @@ class Activity():
             session_vars[name] = {'version': version }
 
         if session_vars:
-            # session_vars should always exist if products exist.
+            # session_vars should always exist if products exist; i.e, any
+            # stage after process-media.
             self.site_conf.manage_session_vars(session_vars, write=True)
 
         # Generate site_parameters and patch the activity.
@@ -623,8 +624,8 @@ class Activity():
             config.logger.debug("Next workflow {}".format(wfid))
             wf = self.get_workflow(config, wfid)
             stage = wf['metadata']['labels']['stage']
-            config.stages.exec_stage(config, wfid, stage)
             self.site_conf.update_dict_stack(stage)
+            config.stages.exec_stage(config, wfid, stage)
 
         return sessionid
 

--- a/lib/SiteConfig.py
+++ b/lib/SiteConfig.py
@@ -282,7 +282,7 @@ class SiteConfig():
             yaml.dump(self.rendered, fhandle)
 
     def update_dict_stack(self, stage):
-        deliver_stage = self.stage_enum["deliver-product"]
+        deliver_stage = self.stage_enum["update-vcs-config"]
         if stage in self.stage_enum:
             stage_index = self.stage_enum[stage]
         else:

--- a/lib/git.py
+++ b/lib/git.py
@@ -205,7 +205,6 @@ class Git:
         """
         clone_url = self.get_vcs_url(repo)
         repoinfo = self.clone_info.get(repo)
-        print(f"(git/clone) clone_url={clone_url}, repoinfo={repoinfo}")
         if repoinfo:
             clonedir = repoinfo["clonedir"]
         else:


### PR DESCRIPTION
1. In lib/Activity.py, update the dictionary stack
   (`self.site_conf.update_dict_stack(stage)`) after calling exect_stage.

2. In iuf, remove the 'process-media' from the bootprep bootprep/stage
   checks in validate_stages -- this should have been 'deliver-product'
   rather than 'process-media', but with the lib/Activity change, we can
   remove it anyway.

3. Fix a few other minor details.
   -- Remove a stray print/debug line in lib/git.py
   -- pass "concurrent_management_rollout_percentage as an int to the API.

A few additional minor fixes are included.  See the commit log.

