### PR TITLE
SCICD-590 Catch unhandled exception in log handling

### DIFF
--- a/lib/PodLogs.py
+++ b/lib/PodLogs.py
@@ -78,10 +78,15 @@ class PodLogs():
 
         kubeconfig.load_kube_config()
         self.core = client.CoreV1Api()
-        service = self.core.read_namespaced_service(name="elasticsearch", namespace="sma")
-        cluster_ip = service.spec.cluster_ip
+        try:
+            service = self.core.read_namespaced_service(name="elasticsearch", namespace="sma")
+            cluster_ip = service.spec.cluster_ip
 
-        self.endpoint = f"http://{cluster_ip}:9200/_search"
+            self.endpoint = f"http://{cluster_ip}:9200/_search"
+        except:
+            self.logger.debug("Unable to find elasticsearch service.")
+            pass
+
         self._finished = False
 
 


### PR DESCRIPTION
* Add a try/except around the elasticsearch setup

Elastic isn't always available during fresh installs which causes the cli to abort.   Just note that it isn't available and move on.