### PR TITLE
SCICD-592 Activity should start at the first state entry (#31)

### DIFF
--- a/lib/Activity.py
+++ b/lib/Activity.py
@@ -95,7 +95,6 @@ class Activity():
                 raise ActivityError(f"{filename} contains the activity {self.name}, but {name} was specified.")
         else:
             self.name = name
-            self.start = self.get_time()
 
             self.initialized = True
             self.write_activity_dict()
@@ -151,11 +150,17 @@ class Activity():
 
         if summary:
             retstring += "\n\nSummary:\n"
-            retstring += "  Start time: " + self.start + "\n"
-            retstring += "    End time: " + ordered_states[-1] + "\n\n"
+            retstring += "   Start time: " + self.start + "\n"
+            retstring += "     End time: " + ordered_states[-1] + "\n\n"
             for astate in ACTIVITY_VALID_STATES:
                 if astate in summary:
                     retstring += f"{astate:>14}: {summary[astate]}\n"
+            retstring += "\n"
+            total_time = self.get_duration(self.start, ordered_states[-1])
+            retstring += f"   Total time: {total_time}\n"
+            if "paused" in summary:
+                active_time = total_time - summary['paused']
+                retstring += f"Unpaused time: {active_time}\n"
 
         return retstring
 
@@ -183,7 +188,6 @@ class Activity():
             activity = masterdict[aname]
 
             self.name = aname
-            self.start = self.get_time(activity["start"])
             self.filename = filename
             self.states = dict()
             if "states" in activity:
@@ -221,6 +225,14 @@ class Activity():
         data = self.yaml()
         with open(self.filename, "w", encoding=encoding) as f:
             f.write(data)
+
+    @property
+    def start(self):
+        ordered_states = sorted(self.states.keys())
+        if ordered_states:
+            return ordered_states[0]
+        else:
+            return self.get_time()
 
     def state(self, timestamp=None, sessionid=None, state=None, status="n/a", comment=None, create=False):
         if timestamp:

--- a/lib/Config.py
+++ b/lib/Config.py
@@ -161,8 +161,11 @@ class Config:
                 break
 
         if not media_dir_ok:
-            self._error("Media directory must exist and reside in {}".format(self.media_base_dir))
-            validated = False
+            func = self._args.get("func", None)
+            # we only care about the media directory if we're installing something
+            if func and func.__name__ == "process_install":
+                self._error("Media directory must exist and reside in {}".format(self.media_base_dir))
+                validated = False
 
         for adir in ["state", "log"]:
             if not self._args.get(f"{adir}_dir", None):


### PR DESCRIPTION
* SCICD-592 Activity should start at the first state entry

* Update the activity so "self.start" is now dynamic
* Update config.py to not require media_dir for non-installs
* Add unpaused/total time to the summary

* Minor tweaks

(cherry picked from commit 4f367e1d73a2a88437b1a4c90a7e41cb39a0313d)

## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [issue id](issue link)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

