### PR TITLE
SCICD-584 Get activity status when the cli is killed

### DIFF
--- a/iuf
+++ b/iuf
@@ -184,8 +184,8 @@ def process_activity(config):
 def process_install(config):
     """Run the install"""
 
-    config.activity.create_activity(config)
-    config.activity.run_stages(config, resume=False)
+    config.activity.create_activity()
+    config.activity.run_stages(resume=False)
 
     config.activity.state(state="waiting_admin")
     install_logger.info("Install completed in {}".format(elapsed_time(config.stages.installer_start)))
@@ -241,17 +241,17 @@ def get_comment(text_or_list):
 
 def process_resume(config):
     """Resume an activity"""
-    config.activity.resume(config)
+    config.activity.resume()
 
 
 def process_restart(config):
     """Restart an activity"""
-    config.activity.restart(config)
+    config.activity.restart()
 
 
 def process_abort(config):
     """Kill the running processes and abort the run."""
-    activity_name = config.activity.abort_activity(config)
+    activity_name = config.activity.abort_activity()
     install_logger.info(f"Aborted activity {activity_name}")
 
 def update_logger_config(config):
@@ -581,7 +581,7 @@ def main():
             print(answer_text)
             if not already_answered:
                 already_answered = True
-                config.activity.abort_activity(config, background_only=True)
+                config.activity.abort_activity(background_only=True)
                 print(f"Use `{script_name} -a {activity} resume` to re-connect")
                 print("Bye!")
                 sys.exit(0)
@@ -590,7 +590,7 @@ def main():
             answer_text = "Forcing an immediate abort"
             already_answered = True
             config.args["force"] = True
-            config.activity.abort_activity(config)
+            config.activity.abort_activity()
             print("Bye!")
             sys.exit(0)
         else:

--- a/iuf
+++ b/iuf
@@ -33,21 +33,17 @@ import os
 import shutil
 import signal
 import sys
-import time
 import traceback
 
 from lib.vars import *
 from lib.InstallLogger import *
 
 from lib.InstallerUtils import elapsed_time
-from lib.InstallerUtils import formatted
 
 from lib.ConfigFile import ConfigFile
 from lib.ConfigFile import InvertableArgument
 import lib.Config
 import lib.Activity
-
-from lib.SiteConfig import read_yaml
 
 # Import lib.stages without the 'as stages' to prevent namespace collisions.
 import lib.stages
@@ -474,7 +470,7 @@ def main():
         help="""Force the abort immediately.""")
 
     activity_sp = subparsers.add_parser("activity", description='Create, display, or annotate activity information.')
-    activity_sp.add_argument("--time", help="A time value used when creating or modifying an activity entry. Must be specified and match an existing time value to modify that entry. Defaults to now.", action="store")
+    activity_sp.add_argument("--time", help="A time value used when creating or modifying an activity entry. Must match an existing time value to modify that entry. Defaults to now.", action="store")
     activity_sp.add_argument("--create", help="Create a new activity entry.", action="store_true", default=False)
     activity_sp.add_argument("--comment", help="A comment to be associated with an activity entry.", action="store")
     activity_sp.add_argument("--status", help="A status value to be associated with an activity entry.", action="store", default="n/a", choices=lib.Activity.ACTIVITY_VALID_STATUS)
@@ -539,9 +535,6 @@ def main():
     config.stages = lib.stages.Stages(stage_dict=STAGE_DICT, state_dir=config.args["state_dir"])
     validate_stages(config)
 
-    if config.args["write_input_file"]:
-        configfile.write(config.args)
-
     atexit.register(log_state_files, config)
 
     if config.args["write_input_file"]:
@@ -560,9 +553,9 @@ def main():
         activity = config.args.get("activity", None)
         script_name = sys.argv[0]
         print("Would you like to abort this run?")
-        print("    Enter Y, y, or yes to abort after the current stage")
+        print("    Enter Y, y, or yes to abort after the current stage.")
         print("    Enter F, f, or force to abort immediately.")
-        print("    Enter D, d, or  or disconnect to exit the IUF CLI.  The install will continue in the background, however no logs will be collected.")
+        print("    Enter D, d, or disconnect to exit the IUF CLI.  The install will continue in the background, however no logs will be collected.")
         print("")
         print("    Enter <return> to resume monitoring.")
         print("    Note all logging will be suspended when backgrounded.")

--- a/lib/Activity.py
+++ b/lib/Activity.py
@@ -574,7 +574,7 @@ class Activity():
 
         self.site_conf = SiteConfig(self.config)
         self.site_conf.organize_merge()
-        self.watch_next_wf(self.config, session)
+        self.watch_next_wf(session)
         self.podlogs.finished = True
 
 
@@ -650,7 +650,7 @@ class Activity():
         if stages[0] == "process-media":
             stages.pop(0)
             payload["input_parameters"]["stages"] = ["process-media"]
-            sid = self.run_stage(self.config, payload)
+            sid = self.run_stage(payload)
             sessions.append(sid)
 
         ret_code = self.api.get_activity(self.name)
@@ -684,7 +684,7 @@ class Activity():
         # Run any remaining stages.
         if stages:
             payload["input_parameters"]["stages"] = stages
-            sid = self.run_stage(self.config, payload)
+            sid = self.run_stage(payload)
             sessions.append(sid)
 
         return sessions
@@ -762,10 +762,10 @@ class Activity():
                     last_stages.pop(0)
                 if backend_stages[0] == "process-media":
                     # 1a -- disconnected in process media.  -- will stop after.
-                    self.monitor_workflow(self.config, last_sessionid)
+                    self.monitor_workflow(last_sessionid)
                     if last_stages:
                         self.config.stages.set_stages(last_stages)
-                        self.run_stages(self.config, resume=True)
+                        self.run_stages(resume=True)
                 else:
                     # 1b -- Disconnected after process-media.  The backend
                     # should have all the necessary stage information.  Just re-attach.

--- a/lib/Config.py
+++ b/lib/Config.py
@@ -62,12 +62,7 @@ class Config:
     def activity(self):
         if self._activity_session is None:
             session = self.args.get("activity", None)
-<<<<<<< HEAD
-            self._activity_session = lib.Activity.Activity(self, name=session,
-                filename=self.activity_dict_file, dryrun=self.dryrun)
-=======
             self._activity_session = lib.Activity.Activity(name=session, filename=self.activity_dict_file, dryrun=self.dryrun, config=self)
->>>>>>> 3a1b0dc (SCICD-584 Check activity status if it isn't complete)
 
         return self._activity_session
 

--- a/lib/Config.py
+++ b/lib/Config.py
@@ -62,8 +62,12 @@ class Config:
     def activity(self):
         if self._activity_session is None:
             session = self.args.get("activity", None)
+<<<<<<< HEAD
             self._activity_session = lib.Activity.Activity(self, name=session,
                 filename=self.activity_dict_file, dryrun=self.dryrun)
+=======
+            self._activity_session = lib.Activity.Activity(name=session, filename=self.activity_dict_file, dryrun=self.dryrun, config=self)
+>>>>>>> 3a1b0dc (SCICD-584 Check activity status if it isn't complete)
 
         return self._activity_session
 
@@ -102,7 +106,6 @@ class Config:
     @property
     def logger(self):
         return get_install_logger()
-        #return self._logger
 
     @property
     def media_base_dir(self):

--- a/lib/SiteConfig.py
+++ b/lib/SiteConfig.py
@@ -162,7 +162,6 @@ class SiteConfig():
         if type(list_of_dicts) != list:
             raise UnexpectedState("merge_dicts called with '{}'.  Expected a list.".format(list_of_dicts))
 
-
         def merge_two_dicts(dict1, dict2):
             for elt in dict2:
                 if elt in dict1:
@@ -243,22 +242,21 @@ class SiteConfig():
 
                 recipe_file = os.path.join(clone_loc, RECIPE_VARS)
                 if os.path.exists(recipe_file):
-                    msg = f"""Neither --recipe-vars nor --bootprep-config-dir
-                    were specified, so {RECIPE_VARS}  will pulled from the
-                    branch {co_branch} of the {repo} git repo."""
+                    msg = ("Neither --recipe-vars nor --bootprep-config-dir were specified, "
+                            f"so {RECIPE_VARS} will be pulled from the branch {co_branch} "
+                            f"of the {repo} git repo.")
                     install_logger.info(formatted(msg))
                     self.recipe_vars = read_yaml(recipe_file)
                 else:
-                    msg = f"""Could not find vcs/{RECIPE_VARS} on branch
-                    {co_branch} within the {repo} repo. If one is desired, it
-                    can be specified with the `--bootprep-config-dir` or
-                    `--recipe-vars` arguments."""
-                    install_logger.warning(msg)
+                    msg = (f"Could not find vcs/{RECIPE_VARS} on branch {co_branch} within "
+                           f"the {repo} repo. If one is desired, it can be specified with the "
+                           "`--bootprep-config-dir` or `--recipe-vars` arguments.")
+                    install_logger.warning(formatted(msg))
             except Exception as e:
-                msg = f"""Could not find vcs/{RECIPE_VARS} within the
-                {repo} repo. If one is desired, it can be specified with the
-                `--bootprep-config-dir` or `--recipe-vars` arguments."""
-                install_logger.warning(msg)
+                msg = (f"Could not find vcs/{RECIPE_VARS} within the "
+                f"{repo} repo. If one is desired, it can be specified with the "
+                "`--bootprep-config-dir` or `--recipe-vars` arguments.")
+                install_logger.warning(formatted(msg))
                 pass
 
         if self.recipe_vars:

--- a/lib/stages.py
+++ b/lib/stages.py
@@ -273,7 +273,7 @@ class Stages():
         try:
             self.current_stage = stage
             stage_start = datetime.datetime.now()
-            status = config.activity.monitor_workflow(config, workflow)
+            status = config.activity.monitor_workflow(workflow)
             config.logger.info(f"         RESULT: {status}")
             if status == "Succeeded":
                 failed = False


### PR DESCRIPTION
When an activity is aborted from a second window, the status updates fine.  But when the cli is killed and the abort is run while it isn't watching, the activity status can get lost.

* Have the activity history get "fixed" during load if it isn't in a debug/waiting state
* Make config a class variable for activity so we can stop passing it in everywhere
* Multiple updates to help/error messages for grammar/wrapping issues
* Update resume/restart functions to include an informational message about what it is doing since it can sit quietly for a while
* Add some error handling to resume and something resembling a reasonable error message