### PR TITLE
SCICD-600 management-nodes-rollout doesn't need site_vars

### DIFF
--- a/iuf
+++ b/iuf
@@ -89,7 +89,7 @@ def validate_stages(config):
     # the variables are resolved in that stage.  Further error-checking
     # related to this is done in SiteConfig.
     if any(stage in local_stages for stage in ["update-vcs-config",
-        "update-cfs-config", "management-nodes-rollout"]):
+        "update-cfs-config"]):
         if not (config.args.get("site_vars", None) or config.args.get("bootprep_config_dir", None) \
             or config.args.get("recipe_vars", None)):
             errors.append("bootprep or vcs stages were called, but none of "


### PR DESCRIPTION
* We shouldn't require site_vars for management-nodes-rollout

## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [issue id](issue link)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

