### PR TITLE
SCICD-597: Need Default Section in session_vars

### DIFF
--- a/lib/SiteConfig.py
+++ b/lib/SiteConfig.py
@@ -340,6 +340,7 @@ class SiteConfig():
 
             # don't render defaults
             if name in ['default']:
+                self.rendered.update({"default": data})
                 continue
 
             try:


### PR DESCRIPTION
The default section wasn't being added to session_vars.  This is a little tricky because we don't want the default section rendered.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* SCICD-597 https://jira-pro.its.hpecorp.net:8443/browse/SCICD-597

### Tested on:

  * gamora





