### PR TITLE
SCICD-605: giving up messages cherry pick

### DIFF
--- a/lib/Activity.py
+++ b/lib/Activity.py
@@ -424,7 +424,7 @@ class Activity():
             try:
                 wflow = self.get_workflow(workflow)
             except Exception as e:
-                self.config.logger.error(f"Unable to get workflow {workflow}: {e}")
+                self.config.logger.debug(f"Unable to get workflow {workflow}: {e}")
                 sys.exit(1)
 
             """ TODO: Need to figure out how to tell if the workflow has failed in some bad way """
@@ -539,7 +539,7 @@ class Activity():
         try:
             wf = self.config.connection.run("kubectl -n argo get Workflow/{workflow} -o yaml".format(workflow=workflow))
         except Exception as e:
-            self.config.logger.error(f"Unable to get workflow {workflow}: {e}")
+            self.config.logger.debug(f"Unable to get workflow {workflow}: {e}")
             sys.exit(1)
 
         return yaml.safe_load(wf.stdout)

--- a/lib/Activity.py
+++ b/lib/Activity.py
@@ -324,7 +324,7 @@ class Activity():
             tmp_session = rsession.json()
             if type(tmp_session) is list:
                 if len(tmp_session) > 1:
-                    install_logger.warning("multiple sessions found.  Taking the first one...")
+                    self.config.logger.warning("multiple sessions found.  Taking the first one...")
                 session = tmp_session[0]
             else:
                 session = tmp_session
@@ -605,7 +605,8 @@ class Activity():
         self.config.stages.set_summary("activity", self.config.args.get("activity"))
         self.config.stages.set_summary("media_dir", self.config.args.get("media_dir"))
         self.config.stages.set_summary("state_dir", self.config.args.get("state_dir"))
-        self.config.stages.set_summary("log_dir", self.config.args.get("log_dir"))
+        logdir = os.path.join(self.config.args.get("log_dir"), self.config.timestamp)
+        self.config.stages.set_summary("log_dir", logdir)
 
         force = self.config.args.get("force", False)
         stages = self.config.stages.stages


### PR DESCRIPTION
This generally fixes the problem where we get the error message,
"Giving up following the log for pod ...".  The main problem was that
we allowed the thread to continue after the pod had already exited.

If we still get this error, we might be able tighten up that logic a bit,
but this should fix the vast majority of cases.

