### PR TITLE
SCICD-605-giving-up-messages

### DIFF
--- a/lib/Activity.py
+++ b/lib/Activity.py
@@ -424,7 +424,7 @@ class Activity():
             try:
                 wflow = self.get_workflow(workflow)
             except Exception as e:
-                self.config.logger.error(f"Unable to get workflow {workflow}: {e}")
+                self.config.logger.debug(f"Unable to get workflow {workflow}: {e}")
                 sys.exit(1)
 
             """ TODO: Need to figure out how to tell if the workflow has failed in some bad way """
@@ -539,7 +539,7 @@ class Activity():
         try:
             wf = self.config.connection.run("kubectl -n argo get Workflow/{workflow} -o yaml".format(workflow=workflow))
         except Exception as e:
-            self.config.logger.error(f"Unable to get workflow {workflow}: {e}")
+            self.config.logger.debug(f"Unable to get workflow {workflow}: {e}")
             sys.exit(1)
 
         return yaml.safe_load(wf.stdout)


### PR DESCRIPTION
This generally fixes the problem where we get the error message,
"Giving up following the log for pod ...".  The main problem was that
we allowed the thread to continue after the pod had already exited.

If we still get this error, we might be able tighten up that logic a bit,
but this should fix the vast majority of cases.

