### PR TITLE
SCICD-604: Restart problems

### DIFF
--- a/lib/Activity.py
+++ b/lib/Activity.py
@@ -335,7 +335,7 @@ class Activity():
                 found = True
                 break
 
-            if "workflows" in session:
+            if status and "workflows" in session:
                 try:
                     for workflow in session['workflows']:
                         if workflow['id'] not in self.workflows:


### PR DESCRIPTION
We need to make sure the status is defined when checking the session.  If status is not defined, it means the API is initializing, and the workflow ID is probably an ID from a previous run.

