### PR TITLE
Update JenkinsFile to support release specific subdirs

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -2,7 +2,7 @@
  *
  *  MIT License
  *
- *  (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+ *  (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a
  *  copy of this software and associated documentation files (the "Software"),
@@ -27,7 +27,14 @@
 
 def pythonImage = 'artifactory.algol60.net/csm-docker/stable/csm-docker-sle-python'
 def pythonVersion = '3.10'
+def major
+def minor
+def patch
 def isStable = env.TAG_NAME != null ? true : false
+if ( isStable ) {
+    (major, minor, patch) = env.TAG_NAME.tokenize('.')
+    major = major.replaceAll("^v","")
+}
 pipeline {
     agent {
         label "metal-gcp-builder"
@@ -35,14 +42,17 @@ pipeline {
 
     options {
         buildDiscarder(logRotator(numToKeepStr: "10"))
-        timeout(time: 20, unit: 'MINUTES')
         disableConcurrentBuilds()
+        timeout(time: 20, unit: 'MINUTES')
         timestamps()
     }
 
     environment {
         NAME = getRepoName()
         VERSION = sh(returnStdout: true, script: "git describe --tags | tr -s '-' '~' | tr -d '^v'").trim()
+        TAG_POINTS_AT_HEAD = sh(returnStdout: true, script: "git tag --points-at HEAD | tr -d '^v'").trim()
+        ADDITIONAL_VERSIONS = "${env.VERSION == env.TAG_POINTS_AT_HEAD ? 'latest' : ''}"
+        SLACK_CHANNEL_ALERTS = "csm-release-alerts"
     }
 
     stages {
@@ -68,54 +78,66 @@ pipeline {
                 stages {
 
                     stage('Prepare: RPMs') {
-
                         agent {
                             docker {
-                                label "metal-gcp-builder"
+                                label 'docker'
                                 reuseNode true
                                 image "${pythonImage}:${pythonVersion}-SLES${sleVersion}"
                             }
                         }
                         steps {
-                            // Inject distro-specific metadata (e.g. which distro and service pack).
-                            runLibraryScript("addRpmMetaData.sh", "${env.NAME}.spec")
-                            sh "make prepare"
-                            sh "git update-index --assume-unchanged ${env.NAME}.spec"
+                            withCredentials([gitUsernamePassword(credentialsId: 'jenkins-algol60-cray-hpe-github-integration')]) {
+                                runLibraryScript("addRpmMetaData.sh", "${env.NAME}.spec")
+                                sh "git update-index --assume-unchanged ${env.NAME}.spec"
+                                sh "echo ${env.BRANCH_NAME}"
+                                sh "env"
+                                sh "make prepare"
+                            }
                         }
                     }
 
                     stage('Build: RPMs') {
-
                         environment {
                             PYTHON_VERSION = "${pythonVersion}"
                         }
                         agent {
                             docker {
-                                label "metal-gcp-builder"
+                                label 'docker'
                                 reuseNode true
                                 image "${pythonImage}:${pythonVersion}-SLES${sleVersion}"
                             }
                         }
                         steps {
-                            sh "make rpm"
+                            withCredentials([gitUsernamePassword(credentialsId: 'jenkins-algol60-cray-hpe-github-integration')]) {
+                                sh "make rpm"
+                            }
                         }
                     }
 
                     stage('Publish: RPMs') {
                         steps {
                             script {
+                                if( isStable ){
+                                    RELEASE_FOLDER = "/${major}.${minor}"
+                                } else {
+                                    RELEASE_FOLDER = ""
+                                }
+                                ADDITIONAL_VERSIONS = ("${env.ADDITIONAL_VERSIONS}" == "null") ? [] : ["${env.ADDITIONAL_VERSIONS}"]
                                 sles_version_parts = "${sleVersion}".tokenize('.')
                                 sles_major = "${sles_version_parts[0]}"
                                 sles_minor = "${sles_version_parts[1]}"
                                 publishCsmRpms(
-                                        arch: "x86_64", isStable: isStable,
-                                        component: env.NAME,
+                                        additionalVersions: ADDITIONAL_VERSIONS,
+                                        arch: "x86_64",
+                                        component: env.NAME + RELEASE_FOLDER,
+                                        isStable: isStable,
                                         os: "sle-${sles_major}sp${sles_minor}",
                                         pattern: "dist/rpmbuild/RPMS/x86_64/*.rpm",
                                 )
                                 publishCsmRpms(
+                                        additionalVersions: ADDITIONAL_VERSIONS,
                                         arch: "src",
-                                        component: env.NAME,
+                                        component: env.NAME + RELEASE_FOLDER,
                                         isStable: isStable,
                                         os: "sle-${sles_major}sp${sles_minor}",
                                         pattern: "dist/rpmbuild/SRPMS/*.rpm",
@@ -127,4 +149,4 @@ pipeline {
             }
         }
     }
-}
+  }

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -82,7 +82,7 @@ pipeline {
                             docker {
                                 label 'docker'
                                 reuseNode true
-                                image "${pythonImage}:${pythonVersion}-SLES${sleVersion}"
+                                image "${pythonImage}:${pythonVersion}"
                             }
                         }
                         steps {
@@ -104,7 +104,7 @@ pipeline {
                             docker {
                                 label 'docker'
                                 reuseNode true
-                                image "${pythonImage}:${pythonVersion}-SLES${sleVersion}"
+                                image "${pythonImage}:${pythonVersion}"
                             }
                         }
                         steps {


### PR DESCRIPTION
This is copied from the docs-csm repo with minor changes for our build (i.e. using the python image, x86_64 rpms, not notifying their slack channel when builds happen)

The end result is now we'll get iuf-cli/1.4 directories on publish, and if the tag matches the latest commit we'll also get a -latest rpm (untested on main)

Also update the python image we were using from 3.10-SLES15.3 to just 3.10 due to recent docker updates.