### PR TITLE
Scicd 631 reentrant locks

### DIFF
--- a/iuf
+++ b/iuf
@@ -55,7 +55,6 @@ import yaml
 
 install_logger = get_install_logger()
 
-
 def validate_stages(config):
     """Validate that all of the various stage related args passed in are valid"""
 
@@ -313,11 +312,14 @@ def get_answer():
     """Read input and handle related exceptions."""
     answer = ""
     try:
+        RLOCK.acquire()
         answer = input()
-    except RuntimeError:
+    except (RuntimeError, EOFError):
         # ctrl-c is being pressed repeatedly. Return anything except the
         # allowed answers.
         answer = "Invalid"
+    finally:
+        RLOCK.release()
     return answer
 
 # Interrupt variables
@@ -572,12 +574,10 @@ def main():
         configfile.write(config.args)
 
     def try_print(txt):
-        while True:
-            try:
-                print(txt)
-                break
-            except RuntimeError:
-                time.sleep(.25)
+        RLOCK.acquire()
+        print(txt)
+        sys.stdout.flush()
+        RLOCK.release()
 
 
     def process_ctrl_c(sig, frameg):
@@ -631,7 +631,6 @@ def main():
 
         else:
             try_print("Continuing...")
-        sys.stdout.flush()
 
     signal.signal(signal.SIGINT, process_ctrl_c)
 

--- a/lib/Activity.py
+++ b/lib/Activity.py
@@ -37,6 +37,7 @@ import gzip
 
 from lib.PodLogs import PodLogs
 from lib.SiteConfig import SiteConfig
+from lib.vars import RLOCK
 
 class StateError(Exception):
     """A wrapper for raising a StateError exception."""
@@ -313,10 +314,13 @@ class Activity():
 
         while not found:
             try:
+                RLOCK.acquire()
                 rsession = self.api.get_activity_session(self.name, sessionid)
+                RLOCK.release()
             except Exception as e:
                 self.config.logger.error(f"Unable to get session {sessionid}: {e}")
                 sys.exit(1)
+
 
             # FIXME:
             # We sometimes abort on this line because rsession returns a list of
@@ -513,7 +517,9 @@ class Activity():
 
         while not completed:
             try:
+                RLOCK.acquire()
                 session = self.api.get_activity_session(self.name, sessionid)
+                RLOCK.release()
             except Exception as e:
                 self.config.logger.error(f"Unable to get session {sessionid}: {e}")
                 sys.exit(1)

--- a/lib/Activity.py
+++ b/lib/Activity.py
@@ -707,6 +707,10 @@ class Activity():
         # Generate site_parameters and patch the activity.
         patched_payload = payload
         patched_payload["site_parameters"] = self.site_conf.site_params
+
+        # Remove the "force" key from input_parameters for the patched
+        # activity.
+        patched_payload["input_parameters"].pop("force", None)
         self.api.patch_activity(self.name, patched_payload)
 
         # Run any remaining stages.

--- a/lib/vars.py
+++ b/lib/vars.py
@@ -25,6 +25,9 @@ from collections import OrderedDict
 import logging
 
 import os
+
+import threading
+
 class VMConnectionException(Exception):
     """A pass-through class."""
 
@@ -138,6 +141,7 @@ MEDIA_VERSIONS = "media_versions.yaml"
 BP_CONFIG_MANAGED = "compute-and-uan-bootprep.yaml"
 BP_CONFIG_MANAGEMENT = "management-bootprep.yaml"
 
+RLOCK = threading.RLock()
 
 # RBD/media/state/activity dir defaults
 RBD_BASE_DIR = "/etc/cray/upgrade/csm"


### PR DESCRIPTION
## Summary and Scope
SCICD-634: Force Key in Patched Payload.
Remove the 'force' key from the patched payload.

SCICD-631: Use Reentrant Locks
Use reentrant locks to prevent RuntimeErrors while printing.

