### PR TITLE
SCICD-617 Suppress git messages (#77)

### DIFF
--- a/lib/SiteConfig.py
+++ b/lib/SiteConfig.py
@@ -237,7 +237,7 @@ class SiteConfig():
                     # If that changes, we could get a lot more elaborate and check
                     # for integration and master branches.
                     co_branch = branches[0]
-                    install_logger.warning(f"Couldn't find a versioned branch for {repo}.  Assuming branch {co_branch}.")
+                    install_logger.debug(f"Couldn't find a versioned branch for {repo}.  Assuming branch {co_branch}.")
                 self.git.checkout("hpc-csm-software-recipe", co_branch)
 
                 recipe_file = os.path.join(clone_loc, RECIPE_VARS)
@@ -251,12 +251,12 @@ class SiteConfig():
                     msg = (f"Could not find vcs/{RECIPE_VARS} on branch {co_branch} within "
                            f"the {repo} repo. If one is desired, it can be specified with the "
                            "`--bootprep-config-dir` or `--recipe-vars` arguments.")
-                    install_logger.warning(formatted(msg))
+                    install_logger.debug(formatted(msg))
             except Exception as e:
                 msg = (f"Could not find vcs/{RECIPE_VARS} within the "
                 f"{repo} repo. If one is desired, it can be specified with the "
                 "`--bootprep-config-dir` or `--recipe-vars` arguments.")
-                install_logger.warning(formatted(msg))
+                install_logger.debug(formatted(msg))
                 pass
 
         if self.recipe_vars:

--- a/lib/git.py
+++ b/lib/git.py
@@ -370,8 +370,8 @@ class Git:
         try:
             result = self.connection.sudo(fullcommand, env=self.env, quiet=quiet, dryrun=dryrun)
         except RunException as err:
-            install_logger.error("git command failed: {}.".format(fullcommand))
-            install_logger.error("         Error was: {}".format(err.stderr))
+            install_logger.debug("git command failed: {}.".format(fullcommand))
+            install_logger.debug("         Error was: {}".format(err.stderr))
             raise
 
         return result


### PR DESCRIPTION
* Change most of the errors/warnings to debug
* Left in a single INFO message for successful usage of the git recipe since that is actually modifying the run

(cherry picked from commit 50a0cdaf63c451e1c490b0b25b264de69070007c)

## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [issue id](issue link)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

