### PR TITLE
SCICD-636: --mask-recipe-prods Doesn't Work Correctly

### DIFF
--- a/iuf
+++ b/iuf
@@ -120,6 +120,13 @@ def validate_stages(config):
             if os.path.exists(management_path):
                 config.args["bootprep_config_management"] = management_path
 
+    if "mask_recipe_prods" in config.args:
+        mrp_type = type(config.args["mask_recipe_prods"]).__name__
+        if mrp_type != "list":
+            # This shouldn't happen via the commandline, but can happen when
+            # specifying the argument via the input file ('-i/--input-file).
+            errors.append(f"-mrp/--mask-recipe-prods requires a list, but the argument was passed as {mrp_type}")
+
 
     def check_bootprep_arg(arg_name):
         """Ensure that if a `sat bootprep` config was specified (and the

--- a/lib/SiteConfig.py
+++ b/lib/SiteConfig.py
@@ -192,8 +192,8 @@ class SiteConfig():
             for prod in self.mask_recipe_prods:
                 # Remove the products specified in `--mask-recipe-prods` from
                 # recipe_vars.
-                self.recipe_vars.pop(prod, None)
-
+                if "version" in self.recipe_vars[prod]:
+                    self.recipe_vars[prod].pop("version")
 
     def organize_merge(self):
         """Merge the dictionaries in the following order:
@@ -292,7 +292,7 @@ class SiteConfig():
             yaml.dump(self.rendered, fhandle)
 
     def update_dict_stack(self, stage):
-        deliver_stage = self.stage_enum["update-vcs-config"]
+        vcs_stage = self.stage_enum["update-vcs-config"]
         if stage in self.stage_enum:
             stage_index = self.stage_enum[stage]
         else:
@@ -301,7 +301,7 @@ class SiteConfig():
             the dictionary stack; but the larger problem is probably the
             unknown {stage} stage."""
             install_logger.warning(msg)
-        if stage_index >= deliver_stage:
+        if stage_index >= vcs_stage:
             self.organize_merge()
             self.manage_session_vars(self.session_vars)
 


### PR DESCRIPTION
If "version" exists, remove recipe_vars[prod]["version"], rather than removing all of recipe_vars[prod].


