### PR TITLE
SCICD-636: --mask-recipe-prods Fix

### DIFF
--- a/iuf
+++ b/iuf
@@ -120,7 +120,7 @@ def validate_stages(config):
             if os.path.exists(management_path):
                 config.args["bootprep_config_management"] = management_path
 
-    if "mask_recipe_prods" in config.args:
+    if "mask_recipe_prods" in config.args and config.args["mask_recipe_prods"]:
         mrp_type = type(config.args["mask_recipe_prods"]).__name__
         if mrp_type != "list":
             # This shouldn't happen via the commandline, but can happen when

--- a/lib/Activity.py
+++ b/lib/Activity.py
@@ -25,6 +25,7 @@
 from xml.sax.handler import property_declaration_handler
 import yaml
 import os
+import copy
 import datetime
 from dateutil import parser
 from prettytable import PrettyTable
@@ -731,7 +732,7 @@ class Activity():
             self.site_conf.manage_session_vars(session_vars, write=True)
 
         # Generate site_parameters and patch the activity.
-        patched_payload = payload
+        patched_payload = copy.deepcopy(payload)
         patched_payload["site_parameters"] = self.site_conf.site_params
 
         # Remove the "force" key from input_parameters for the patched


### PR DESCRIPTION
We need to check that config.args["mask_recipe_prod"] is defined before checking it's type.

Also, we need to do a copy.deepcopy of the payload when assigning it to patched_payload, so that when the "force" element is removed from patched_payload, it's not also removed from payload.


