### PR TITLE
SCICD-640: Repeated Log Output

### DIFF
--- a/lib/InstallerUtils.py
+++ b/lib/InstallerUtils.py
@@ -141,7 +141,7 @@ def get_product_catalog(config, all_products=False):
 
 
 
-def elapsed_time(start_time):
+def elapsed_time(start_time, to_str=True):
     """
     return elapsed time in H:M:S format
     """
@@ -149,4 +149,7 @@ def elapsed_time(start_time):
     seconds_waited = int(dt_diff.total_seconds())
     time_waited = str(datetime.timedelta(seconds=seconds_waited))
 
-    return time_waited
+    if to_str:
+        return time_waited
+    else:
+        return seconds_waited


### PR DESCRIPTION
In lib/PodsLogs.py, add "seconds_since" to watch_kwargs so that the output is not always from the beginning of the file.

In lib/InstallerUtils.py, add a to_str argument to elapsed_time, so that the elapsed time can be returned as a string or an int.

