### PR TITLE
SCICD-659: Add the Media Directory and Commands to activity_dict.yaml.

### DIFF
--- a/iuf
+++ b/iuf
@@ -215,14 +215,14 @@ def process_activity(config):
     state = config.args.get("state", None)
     if state:
         try:
-            config.activity.state(
-                timestamp=config.args.get("time", None),
-                sessionid=config.args.get("argo_workflow_id", None),
-                status=config.args.get("status", "n/a"),
-                comment=config.args.get("comment", None),
-                state=state,
-                create=config.args.get("create", False)
-            )
+            config.activity.state({
+                "timestamp": config.args.get("time", None),
+                "sessionid": config.args.get("argo_workflow_id", None),
+                "status": config.args.get("status", "n/a"),
+                "comment": config.args.get("comment", None),
+                "state": state,
+                "create": config.args.get("create", False),
+            })
         except Exception as e:
             install_logger.error(f"{e}")
             install_logger.debug(traceback.format_exc())
@@ -237,7 +237,7 @@ def process_install(config):
     config.activity.create_activity()
     config.activity.run_stages(resume=False)
 
-    config.activity.state(state="waiting_admin")
+    config.activity.state({"state": "waiting_admin"})
     install_logger.info("Install completed in {}".format(elapsed_time(config.stages.installer_start)))
     summary = config.stages.get_summary()
     dashes = "----------------"
@@ -259,8 +259,6 @@ def process_list(config): #pylint: disable=unused-argument
         else:
             all_stages = config.stages.get(long=True, status=True, all_stages=True, list_fmt=False)
             summary = config.stages.get_summary(load=True)
-
-
 
     print(all_stages)
     if summary:
@@ -402,7 +400,7 @@ def print_extra_summary(config):
 
 
 def initialization(config, args):
-    """Config/Activity-specific initilization."""
+    """Config/Activity-specific initialization."""
 
     # Convert the args to a dict, and use that rather than the argparse
     # object.  This is so that we have a dictionary of all options, so that
@@ -417,27 +415,24 @@ def initialization(config, args):
 
     process_debug_level(config)
     update_logger_config(config)
-    install_logger.debug(config.args)
+    install_logger.debug("IUF Command: {}".format(" ".join(sys.argv)))
+    install_logger.debug(f"args: {config.args}")
 
-    config_error = False
+    init_errors = []
 
     if not lib.Activity.valid_activity_name(args.activity):
-        install_logger.error(f"Activity {args.activity} invalid. Names must only contain lowercase letters, numbers, periods, and dashes")
-        config_error = True
+        init_errors.append(f"Activity {args.activity} invalid. Names must only contain lowercase letters, numbers, periods, and dashes")
 
     if len(sys.argv) < 2:
-        install_logger.error("{} requires at least 1 argument".format(sys.argv[0]))
-        config_error = True
-
-    if config_error:
-        parser.print_help(sys.stderr)
-        sys.exit(1)
+        init_errors.append("{} requires at least 1 argument".format(sys.argv[0]))
 
     config.stages = lib.stages.Stages(stage_dict=STAGE_DICT, state_dir=config.args["state_dir"])
     validate_stages(config)
 
     atexit.register(log_state_files, config)
     atexit.register(print_extra_summary, config)
+
+    return init_errors
 
 
 def get_answer():
@@ -674,8 +669,14 @@ def main():
 
     # parse the command line for real
     args = parser.parse_args()
-    initialization(config, args)
-    if not args.activity and args.func in [process_install, process_activity]:
+    init_errors = initialization(config, args)
+    if init_errors:
+        for err in init_errors:
+            install_logger.error(err)
+        parser.print_help(sys.stderr)
+        sys.exit(1)
+
+    if not args.activity and hasattr(args, "func") and args.func in [process_install, process_activity]:
         print("ERROR: --activity is required.")
         parser.print_help(sys.stderr)
         sys.exit(1)

--- a/lib/Config.py
+++ b/lib/Config.py
@@ -174,19 +174,26 @@ class Config:
             sys.exit(1)
 
     def check_media_dir(self, stages):
-        if self._args.get("media_dir", None) is None:
-            # if `--media-dir` was not specified on the commandline, default
-            # it to self.media_base_dir/self.activity.name
-            self._args["media_dir"] = os.path.join(self.media_base_dir, self.activity.name)
 
-        media_dir_ok = False
-        media_dir = self._args.get("media_dir")
+        # Ensure the activity is initialized.  This will result in the
+        # activity dictionary being read, and possibly getting the last
+        # media_dir used.
+        media_dir = self.activity.media_dir
 
-        for adir in [media_dir, os.path.abspath(media_dir), os.path.join(self.media_base_dir, media_dir)]:
-            if adir.startswith(self.media_base_dir) and os.path.exists(adir):
+        if media_dir is None:
+            # media_dir wasn't found in the activity dictionary.
+            activity_dir = os.path.join(self.media_base_dir, self.activity.name)
+            if os.path.exists(activity_dir):
+                self.activity.media_dir = activity_dir
                 media_dir_ok = True
-                self._args["media_dir"] = adir
-                break
+        else:
+            # media_dir is set.  Ensure  if a relative path was specified,
+            # it expands into an absolute path correctly; i.e, the path exists.
+            for adir in [media_dir, os.path.abspath(media_dir), os.path.join(self.media_base_dir, media_dir)]:
+                if adir.startswith(self.media_base_dir) and os.path.exists(adir):
+                    media_dir_ok = True
+                    self.activity.media_dir = adir
+                    break
 
         if not media_dir_ok:
             func = self._args.get("func", None)

--- a/lib/stages.py
+++ b/lib/stages.py
@@ -259,7 +259,15 @@ class Stages():
 
         config.logger.info(f"      IUF STAGE: {stage}")
         config.logger.info(f"  ARGO WORKFLOW: {workflow}")
-        utime = config.activity.state(state="in_progress", status="Running", sessionid=workflow, comment=f"Run {stage}")
+        state_args = {
+            "state": "in_progress",
+            "status": "Running",
+            "sessionid": workflow,
+            "comment": f"Run {stage}",
+            "command": " ".join(sys.argv),
+            "media_dir": config.args.get("media_dir")
+        }
+        utime = config.activity.state(state_args)
 
         # Execute the stage.
         failed = True
@@ -279,9 +287,9 @@ class Stages():
             config.logger.info(f"       DURATION: {duration}")
 
             # update the current state with the failure
-            config.activity.state(timestamp=utime, status="Failed")
+            config.activity.state({"timestamp":utime, "status":"Failed"})
             # put the whole process into debug
-            config.activity.state(state="debug", comment=f"Exception occurred while executing {err.cmd}")
+            config.activity.state({"state": "debug", "comment": f"Exception occurred while executing {err.cmd}"})
 
             install_logger.debug("Exception while executing %s", stage, exc_info=True)
             print("")
@@ -300,9 +308,9 @@ class Stages():
             duration = elapsed_time(stage_start)
             config.logger.info(f"       DURATION: {duration}")
             # update the current state with the failure
-            config.activity.state(timestamp=utime, status="Failed")
+            config.activity.state({"timestamp":utime, "status":"Failed"})
             # put the whole process into debug
-            config.activity.state(state="debug", comment=str(err))
+            config.activity.state({"state":"debug", "comment":str(err)})
 
             install_logger.debug("Exception while executing %s", stage, exc_info=True)
             print("")
@@ -315,14 +323,14 @@ class Stages():
             print("")
             self.stage_hist.update(stage, ran=False, succeeded="Paused",duration=duration)
             # update the current state with the failure
-            config.activity.state(timestamp=utime, status="Failed")
+            config.activity.state({"timestamp": utime, "status":"Failed"})
             # put the whole process into debug
-            config.activity.state(state="debug")
+            config.activity.state({"state":"debug"})
 
             print(self.get_summary())
             sys.exit(1)
         else:
-            config.activity.state(timestamp=utime, status="Succeeded")
+            config.activity.state({"timestamp":utime, "status":"Succeeded"})
             self.stage_hist.update(stage, True, True, duration=duration)
 
     def set_skipped(self, skipped_stages=[]):


### PR DESCRIPTION
Add the media directory and commands to activity_dict.yaml.  Also, dump the worflow info to $STATE_DIR/sessions/$SESSION_ID.  This is useful for debugging.

The bulk of these changes relate to changing the definition of the state function within the Activity class.  Two more arguments would have needed to be added, so the definition was changed to use a dictionary rather than listing each argument explicitly.

This PR also resolves the following:
SCICD-665: Stack Traces with No Arguments
We need to check if args has a func attribute prior to checking it's value.

SCICD-667: Argo Log Flat Files Truncated.
The code was breaking early and exiting.  We don't need the break, because the individual threads will get cleaned up once the pod quits running.  So All we really need to do is remove the break statement.

SCICD-662: Stack Trace when moving leader
When migrating pods, the pod won't be available for a few seconds, and urllib3.exceptions.MaxRetryError will be raise.  Catch this exception and continue to poll for POLL_LOGS seconds.

