### PR TITLE
SCICD-672: Media Dir Problems

### DIFF
--- a/lib/Activity.py
+++ b/lib/Activity.py
@@ -211,7 +211,7 @@ class Activity():
 
     @property
     def media_dir(self):
-        if not self._media_dir:
+        if not self._media_dir and self.states:
             ordered_states = sorted(self.states.keys())
             last_state = self.states[ordered_states[-1]]
             sessionid = last_state.get("sessionid", None)


### PR DESCRIPTION
When an activity is new, the activity_dict.yaml will not be populated yet. This needs to be accounted for within the `media_dir` function within Activity.py.


