### PR TITLE
SCICD-672: set media_dir_ok

### DIFF
--- a/lib/Config.py
+++ b/lib/Config.py
@@ -178,6 +178,7 @@ class Config:
         # Ensure the activity is initialized.  This will result in the
         # activity dictionary being read, and possibly getting the last
         # media_dir used.
+        media_dir_ok = False
         media_dir = self.activity.media_dir
 
         if media_dir is None:


### PR DESCRIPTION
media_dir_ok needs to be initialized before it can be used.

