### PR TITLE
SCICD-504: Sanity Checks

### DIFF
--- a/iuf
+++ b/iuf
@@ -46,7 +46,7 @@ from lib.ConfigFile import ConfigFile
 from lib.ConfigFile import InvertableArgument
 import lib.Config
 import lib.Activity
-
+from lib.Activity import ACTIVITY_VALID_STATES
 # Import lib.stages without the 'as stages' to prevent namespace collisions.
 import lib.stages
 
@@ -249,7 +249,10 @@ def process_activity(config):
             install_logger.error(f"{e}")
             install_logger.debug(traceback.format_exc())
             sys.exit(1)
-
+    elif config.args.get("create", False) :
+        install_logger.error("The `--create` flag was passed without the <state> positional parameter")
+        install_logger.error("Please include one of the following states: {}".format(", ".join(ACTIVITY_VALID_STATES)))
+        sys.exit(1)
     print(config.activity)
 
 
@@ -385,7 +388,7 @@ def print_extra_summary(config):
             for line in lines:
                 if "ERROR" in line or "INFO" in line:
                     try:
-                        timestamp, level, msg = line.strip().split(" ", 2)
+                        _, level, msg = line.strip().split(" ", 2)
                         message = msg.strip()
                         if level == "ERROR":
                             if message.startswith("FINISHED"):

--- a/lib/Config.py
+++ b/lib/Config.py
@@ -182,32 +182,14 @@ class Config:
         if not validated:
             sys.exit(1)
 
+
     def check_media_dir(self, stages):
-
-        # Ensure the activity is initialized.  This will result in the
-        # activity dictionary being read, and possibly getting the last
-        # media_dir used.
-        media_dir_ok = False
         media_dir = self.activity.media_dir
-
-        if media_dir is None:
-            # media_dir wasn't found in the activity dictionary or specified
-            # via the commandline.
-            activity_dir = os.path.join(self.media_base_dir, self.activity.name)
-            if os.path.exists(activity_dir):
-                self.activity.media_dir = activity_dir
-                media_dir_ok = True
-        else:
-            # media_dir is set.  Ensure  if a relative path was specified,
-            # it expands into an absolute path correctly; i.e, the path exists.
-            for adir in [media_dir, os.path.abspath(media_dir), os.path.join(self.media_base_dir, media_dir)]:
-                if adir.startswith(self.media_base_dir) and os.path.exists(adir):
-                    media_dir_ok = True
-                    self.activity.media_dir = adir
-                    break
-
-        if not media_dir_ok:
+        if not media_dir.startswith(self.media_base_dir):
             func = self._args.get("func", None)
-            if func.__name__ ==  "process_install" and "process-media" in stages:
+            if func and func.__name__ == "process_install" and "process-media" in stages:
                 self._error(f"Media directory must exist and reside in {self.media_base_dir}")
                 sys.exit(1)
+        self._args["media_dir"] = media_dir
+
+

--- a/lib/PodLogs.py
+++ b/lib/PodLogs.py
@@ -28,8 +28,8 @@ import requests
 import threading
 import time
 
-from urllib3.exceptions import ReadTimeoutError as ReadTimeoutError
-from urllib3.exceptions import MaxRetryError as MaxRetryError
+from urllib3.exceptions import ReadTimeoutError
+from urllib3.exceptions import MaxRetryError
 
 from kubernetes import client, watch
 from kubernetes import config as kubeconfig
@@ -261,7 +261,7 @@ class PodLogs():
                 total_polled_time = datetime.datetime.now() - start_poll
                 polled_seconds = int(total_polled_time.seconds)
                 if polled_seconds >= POLL_LOGS:
-                    install_logger.warning(f"Giving up following the log for pod {pod}!")
+                    install_logger.debug(f"Giving up following the log for pod {pod}!")
                     return
                 last_read = datetime.datetime.now()
                 time.sleep(.5)
@@ -269,7 +269,11 @@ class PodLogs():
                 # Timed out reading in the watcher.stream(...).  The
                 # timeout is low, so just continue.
                 last_read = datetime.datetime.now()
-                continue
+            except Exception as exc:
+                install_logger.debug("Caught unhandled exception in PodLogs:")
+                install_logger.debug(f"\tname={exc.__class__.__name__}")
+                install_logger.debug(f"\tException={exc}")
+                last_read = datetime.datetime.now()
 
             if st_event.is_set():
                 # The threads are being collected.

--- a/lib/vars.py
+++ b/lib/vars.py
@@ -151,7 +151,7 @@ RLOCK = threading.RLock()
 RBD_BASE_DIR = "/etc/cray/upgrade/csm"
 IUF_BASE_DIR = os.path.join(RBD_BASE_DIR, "iuf")
 ACTIVITY_BASE_DIR = os.path.join(IUF_BASE_DIR, "activities")
-MEDIA_BASE_DIR = "/opt/cray/iuf"
+MEDIA_BASE_DIR = RBD_BASE_DIR
 
 LOG_DEFAULT_CONSOLE_LEVEL = logging.INFO
 LOG_DEFAULT_FILE_LEVEL = logging.DEBUG


### PR DESCRIPTION
Check the media directory for new tarballs that haven't been run through process-media yet.

Ensure the media_dir is always defined.  It doesn't always need to be explicitly specified, but we should be able to determine what it is.  If it cannot be determined, it is an error.


