### PR TITLE
Scicd -618, 681, and 682 cherry pick

### DIFF
--- a/iuf
+++ b/iuf
@@ -46,7 +46,7 @@ from lib.ConfigFile import ConfigFile
 from lib.ConfigFile import InvertableArgument
 import lib.Config
 import lib.Activity
-
+from lib.Activity import ACTIVITY_VALID_STATES
 # Import lib.stages without the 'as stages' to prevent namespace collisions.
 import lib.stages
 
@@ -249,7 +249,10 @@ def process_activity(config):
             install_logger.error(f"{e}")
             install_logger.debug(traceback.format_exc())
             sys.exit(1)
-
+    elif config.args.get("create", False) :
+        install_logger.error("The `--create` flag was passed without the <state> positional parameter")
+        install_logger.error("Please include one of the following states: {}".format(", ".join(ACTIVITY_VALID_STATES)))
+        sys.exit(1)
     print(config.activity)
 
 
@@ -385,7 +388,7 @@ def print_extra_summary(config):
             for line in lines:
                 if "ERROR" in line or "INFO" in line:
                     try:
-                        timestamp, level, msg = line.strip().split(" ", 2)
+                        _, level, msg = line.strip().split(" ", 2)
                         message = msg.strip()
                         if level == "ERROR":
                             if message.startswith("FINISHED"):

--- a/lib/PodLogs.py
+++ b/lib/PodLogs.py
@@ -28,8 +28,8 @@ import requests
 import threading
 import time
 
-from urllib3.exceptions import ReadTimeoutError as ReadTimeoutError
-from urllib3.exceptions import MaxRetryError as MaxRetryError
+from urllib3.exceptions import ReadTimeoutError
+from urllib3.exceptions import MaxRetryError
 
 from kubernetes import client, watch
 from kubernetes import config as kubeconfig
@@ -261,7 +261,7 @@ class PodLogs():
                 total_polled_time = datetime.datetime.now() - start_poll
                 polled_seconds = int(total_polled_time.seconds)
                 if polled_seconds >= POLL_LOGS:
-                    install_logger.warning(f"Giving up following the log for pod {pod}!")
+                    install_logger.debug(f"Giving up following the log for pod {pod}!")
                     return
                 last_read = datetime.datetime.now()
                 time.sleep(.5)
@@ -269,7 +269,11 @@ class PodLogs():
                 # Timed out reading in the watcher.stream(...).  The
                 # timeout is low, so just continue.
                 last_read = datetime.datetime.now()
-                continue
+            except Exception as exc:
+                install_logger.debug("Caught unhandled exception in PodLogs:")
+                install_logger.debug(f"\tname={exc.__class__.__name__}")
+                install_logger.debug(f"\tException={exc}")
+                last_read = datetime.datetime.now()
 
             if st_event.is_set():
                 # The threads are being collected.

--- a/lib/vars.py
+++ b/lib/vars.py
@@ -151,7 +151,7 @@ RLOCK = threading.RLock()
 RBD_BASE_DIR = "/etc/cray/upgrade/csm"
 IUF_BASE_DIR = os.path.join(RBD_BASE_DIR, "iuf")
 ACTIVITY_BASE_DIR = os.path.join(IUF_BASE_DIR, "activities")
-MEDIA_BASE_DIR = "/opt/cray/iuf"
+MEDIA_BASE_DIR = RBD_BASE_DIR
 
 LOG_DEFAULT_CONSOLE_LEVEL = logging.INFO
 LOG_DEFAULT_FILE_LEVEL = logging.DEBUG


### PR DESCRIPTION
SCICD-618: Create Did Not Return an Error
Issue an error if the '--create' flag was passed to activity without
specifying the state positional argument.

SCICD-681: Catch a General Exception in PodLogs
In PodLogs, catch a general exception and print a debug log message.

SCICD-682: Media Dir is getting set to /opt/cray/iuf
The media directory should default to the RBD_BASE_DIR rather than
/opt/cray/iuf.

