### PR TITLE
SCICD-619: Ctrl-C Problems

### DIFF
--- a/iuf
+++ b/iuf
@@ -493,9 +493,12 @@ def main():
         Can also be set via the IUF_INPUT_FILE environment variable.""")
 
     parser.add_argument("-w", "--write-input-file", action="store_true",
-        help="""Create a new input file populated with default values overridden by any other command
-        line options also specified. The file is named via the `-i` argument. The command exits once
-        the file has been created.""")
+        help="""Create an input file for iuf populated with the command line
+        options specified and exit.  This input file can be specified with
+        the `-i` option on subsequent runs.  Using an input file simplifies
+        iuf commands with many options.  Note that the general iuf command
+        does not change; so for a long iuf command, add this flag to the
+        command to write the input file.""")
 
     ### TODO, make default value product_vars.yaml 'recipe', fallback to pwd
     parser.add_argument("-a", "--activity", action="store",

--- a/iuf
+++ b/iuf
@@ -713,8 +713,8 @@ def main():
 
         thispid = os.getpid()
         if thispid != mypid:
-            # The interrupt is sent to all threads, so return
-            # if this is not the main thread.
+            # The interrupt is sent to all processes, so return
+            # if this is not the parent process.
             return
 
         if already_answered and answer_text:

--- a/iuf
+++ b/iuf
@@ -464,19 +464,17 @@ def get_answer():
     """Read input and handle related exceptions."""
     answer = ""
     try:
-        RLOCK.acquire()
         answer = input()
     except (RuntimeError, EOFError):
         # ctrl-c is being pressed repeatedly. Return anything except the
         # allowed answers.
         answer = "Invalid"
-    finally:
-        RLOCK.release()
     return answer
 
 # Interrupt variables
 already_answered = False
 answer_text = None
+mypid = os.getpid()
 
 def main():
     """Main entry point."""
@@ -706,33 +704,34 @@ def main():
         parser.print_help(sys.stderr)
         sys.exit(1)
 
-    def try_print(txt):
-        RLOCK.acquire()
-        print(txt)
-        sys.stdout.flush()
-        RLOCK.release()
 
 
     def process_ctrl_c(sig, frameg):
         """Override a ctrl-c interrupt."""
-        global already_answered, answer_text
+        global already_answered, answer_text, mypid
 
-        if already_answered and answer_text:
-            try_print(answer_text)
+
+        thispid = os.getpid()
+        if thispid != mypid:
+            # The interrupt is sent to all threads, so return
+            # if this is not the main thread.
             return
 
-        proccessing_interrupt = True
+        if already_answered and answer_text:
+            print(answer_text)
+            return
+
         activity = config.args.get("activity", None)
         script_name = sys.argv[0]
 
-        try_print("Would you like to abort this run?")
-        try_print("    Enter Y, y, or yes to abort after the current stage completes.")
-        try_print("    Enter F, f, or force to abort the current stage immediately.")
-        try_print("    Enter D, d, or disconnect to exit the IUF CLI.  The install will continue in the background, however no logs will be collected.")
-        try_print("")
-        try_print("    Enter <return> to resume monitoring.")
-        try_print("    NOTE: The IUF CLI will remain connected until Argo completes the abort process.  Use the disconnect option to exit the IUF CLI immediately.")
-        try_print("    NOTE: All logging will be suspended when disconnected.")
+        print("Would you like to abort this run?")
+        print("    Enter Y, y, or yes to abort after the current stage completes.")
+        print("    Enter F, f, or force to abort the current stage immediately.")
+        print("    Enter D, d, or disconnect to exit the IUF CLI.  The install will continue in the background, however no logs will be collected.")
+        print("")
+        print("    Enter <return> to resume monitoring.")
+        print("    NOTE: The IUF CLI will remain connected until Argo completes the abort process.  Use the disconnect option to exit the IUF CLI immediately.")
+        print("    NOTE: All logging will be suspended when disconnected.")
 
         literal_answer = get_answer()
         answer = literal_answer.lower()
@@ -740,30 +739,30 @@ def main():
         if answer in ["y", "yes"]:
             answer_text = "Aborting after the current stage completes."
             if not already_answered:
-                try_print(answer_text)
+                print(answer_text)
                 already_answered = True
                 process_abort(config)
 
         elif answer in ["d", "disconnect"]:
             answer_text = "Attempting to exit the CLI cleanly."
-            try_print(answer_text)
+            print(answer_text)
             if not already_answered:
                 already_answered = True
                 config.activity.abort_activity(background_only=True)
-                try_print(f"Use `{script_name} -a {activity} resume` to re-connect")
-                try_print("Bye!")
-                sys.exit(0)
+                print(f"Use `{script_name} -a {activity} resume` to re-connect")
+                print("Bye!")
 
         elif answer in ["f", "force"]:
             answer_text = "Forcing an immediate abort."
             already_answered = True
             config.args["force"] = True
             config.activity.abort_activity()
-            try_print("Bye!")
-            sys.exit(0)
-
+            print("Bye!")
         else:
-            try_print("Continuing...")
+            print("Continuing...")
+
+        #  Save cycles if if ctrl-c is being held down.
+        time.sleep(.25)
 
     signal.signal(signal.SIGINT, process_ctrl_c)
 

--- a/lib/Activity.py
+++ b/lib/Activity.py
@@ -42,7 +42,6 @@ import lib.ApiInterface
 from lib.PodLogs import PodLogs
 from lib.SiteConfig import SiteConfig
 from lib.InstallerUtils import formatted
-from lib.vars import RLOCK
 
 class StateError(Exception):
     """A wrapper for raising a StateError exception."""
@@ -402,9 +401,7 @@ class Activity():
 
         while not found:
             try:
-                RLOCK.acquire()
                 rsession = self.api.get_activity_session(self.name, sessionid)
-                RLOCK.release()
             except Exception as e:
                 self.config.logger.error(f"Unable to get session {sessionid}: {e}")
                 sys.exit(1)
@@ -605,9 +602,7 @@ class Activity():
 
         while not completed:
             try:
-                RLOCK.acquire()
                 session = self.api.get_activity_session(self.name, sessionid)
-                RLOCK.release()
             except Exception as e:
                 self.config.logger.error(f"Unable to get session {sessionid}: {e}")
                 sys.exit(1)

--- a/lib/Activity.py
+++ b/lib/Activity.py
@@ -505,9 +505,9 @@ class Activity():
             }
 
 
-        # Launch threads for the pod logs and continue on.  Gather the
-        # threads after the while loop.
-        self.podlogs.follow_pod_logs() # threaded at top-level, no waiting.
+        # Launch processs for the pod logs and continue on.  Gather the
+        # processses after the while loop.
+        self.podlogs.follow_pod_logs() # forked at top-level, no waiting.
         printed_s3 = {}
         while not finished:
             try:
@@ -591,7 +591,7 @@ class Activity():
             if not finished:
                 time.sleep(1)
 
-        self.podlogs.collect_threads()
+        self.podlogs.collect_procs()
         return rstatus
 
     def monitor_session(self, sessionid, stime):
@@ -637,10 +637,10 @@ class Activity():
         """Abort an activity."""
 
         if background_only:
-            # If podlogs aren't initialized yet, skip collecting threads,
+            # If podlogs aren't initialized yet, skip collecting processes,
             # since there will not be any.
             if self.podlogs:
-                self.podlogs.collect_threads()
+                self.podlogs.collect_procs()
             return
 
         comment_arg = self.config.args.get("comment", "")
@@ -658,7 +658,7 @@ class Activity():
         try:
             self.config.logger.debug(f"sending an abort, background_only={background_only}, payload={payload}")
             self.api.abort_activity(self.name, payload)
-            self.podlogs.collect_threads()
+            self.podlogs.collect_procs()
         except requests.ReadTimeout:
             self.config.logger.warning("Timed out sending an abort request.")
             self.config.logger.warning(f"Ensure the argo workflow for {self.name} is not running.")

--- a/lib/vars.py
+++ b/lib/vars.py
@@ -26,8 +26,6 @@ import logging
 
 import os
 
-import threading
-
 class VMConnectionException(Exception):
     """A pass-through class."""
 
@@ -145,7 +143,6 @@ MEDIA_VERSIONS = "media_versions.yaml"
 BP_CONFIG_MANAGED = "compute-and-uan-bootprep.yaml"
 BP_CONFIG_MANAGEMENT = "management-bootprep.yaml"
 
-RLOCK = threading.RLock()
 
 # RBD/media/state/activity dir defaults
 RBD_BASE_DIR = "/etc/cray/upgrade/csm"


### PR DESCRIPTION
Using the threading module requires a lot of context-switching overhead when switching between threads, and the CPU was always maxed out, so the Ctrl-C's seemed unresponsive.  Switch to using the multiprocessing module. This seems to keep the Ctrl-C's responsive.

Put a wrapper around `self.core.list_namespaced_pod` in PodLogs.py. When spamming Ctrl-C's, it encounters network errors.  It's still possible to hit network errors, but this makes it more resilient.  A user needs to really try to hit the network errors now.

Start the PodLog processes with a nice value of 20.  This is as nice as they can get.  Also, clean up entries in `self._running_subthreads` as pods finish to reduce the memory usage.

With the change of threading model, it's not necessary to worry about the reentry locks, so delete initialization of RLOCK from vars.py, and it's usage from iuf and Activity.py.

In iuf, sleep for a fraction of a second while handling the Ctrl-C interrupts. It saves a little processing if a user is holding down the key and spamming them.


