### PR TITLE
SCICD-702: Bootprep Summary

### DIFF
--- a/iuf
+++ b/iuf
@@ -418,6 +418,10 @@ def print_extra_summary(config):
             for artifact in list(dict.fromkeys(artifacts)):
                 print("  ", artifact)
 
+        if config.activity.bootprep_commands:
+            print("sat can be run manually with the following commands:")
+            print(config.activity.bootprep_commands)
+
         if len(error_messages) > 0:
             print("")
             print("Error Summary:")
@@ -447,7 +451,7 @@ def initialization(config, args):
     process_debug_level(config)
     update_logger_config(config)
     shorten_log_status()
-    
+
     install_logger.debug("IUF Command: {}".format(" ".join(sys.argv)))
     install_logger.debug(f"args: {config.args}")
 

--- a/lib/Activity.py
+++ b/lib/Activity.py
@@ -888,6 +888,13 @@ class Activity():
 
         return sessions
 
+    @property
+    def bootprep_commands(self):
+        if self.site_conf and self.site_conf.bootprep_commands:
+            return "\n".join(self.site_conf.bootprep_commands)
+        else:
+            return ""
+
     def watch_next_wf(self, sessionid):
         while True:
             wfid = self.get_next_workflow(sessionid)

--- a/lib/vars.py
+++ b/lib/vars.py
@@ -142,6 +142,7 @@ RECIPE_VARS="product_vars.yaml"
 MEDIA_VERSIONS = "media_versions.yaml"
 BP_CONFIG_MANAGED = "compute-and-uan-bootprep.yaml"
 BP_CONFIG_MANAGEMENT = "management-bootprep.yaml"
+SESSION_VARS = "session_vars.yaml"
 
 
 # RBD/media/state/activity dir defaults


### PR DESCRIPTION
Provide a summary of the bootprep commands that were run.  This allows
a user to be able to re-run the commands without having to run iuf.
As an example, the summary after running the prepare-images stage
may be as follows:

Install Summary
activity: ltordsen.15
command line: ./iuf -i input.yaml run -r prepare-images
log dir: /etc/cray/upgrade/csm/iuf/ltordsen.15/log/20230503151930
media dir: /etc/cray/upgrade/csm/ltordsen.15
site vars: /etc/cray/upgrade/csm/iuf/ltordsen.15/state/session_vars.yaml
state dir: /etc/cray/upgrade/csm/iuf/ltordsen.15/state
sat can be run manually with the following commands:

    cd /etc/cray/upgrade/csm/ltordsen.15
    sat bootprep run --limit session_templates --overwrite-configs \
    --vars-file "session_vars.yaml" --format json --bos-version v2 \
    .bootprep-ltordsen.15/management-bootprep.yaml

    cd /etc/cray/upgrade/csm/ltordsen.15
    sat bootprep run --limit session_templates --overwrite-configs \
    --vars-file "session_vars.yaml" --format json --bos-version v2 \
