### PR TITLE
CASMINST-6208 change limit-mangement-rollout to default to empty list

### DIFF
--- a/iuf
+++ b/iuf
@@ -639,9 +639,10 @@ def main():
        Defaults to the Compute role.""")
 
     run_sp.add_argument("--limit-management-rollout", action="store", nargs='+',
-        default=["Management_Worker"],
-        help="""Override list used to target specific role_subrole(s) only when rolling out management nodes.
-        Defaults to the Management_Worker role.""")
+        default=[],
+        help="""List used to target specific hostnames or HSM management role_subrole only when rolling 
+        out management nodes. Hostname arguments can only belong to a single node type. For example, 
+        both master and worker hostnames can not be provided at the same time. Defaults to an empty list.""")
 
     run_sp.add_argument("-mrp", "--mask-recipe-prods", action="store", nargs='+',
         help="""If `--recipe-vars` is specified, mask the versions found within the recipe variables YAML

--- a/iuf
+++ b/iuf
@@ -710,7 +710,8 @@ def main():
         default=[],
         help="""List used to target specific hostnames or HSM management role_subrole only when rolling 
         out management nodes. Hostname arguments can only belong to a single node type. For example, 
-        both master and worker hostnames can not be provided at the same time. Defaults to an empty list.""")
+        both master and worker hostnames can not be provided at the same time. Defaults to an empty list
+        which means no nodes will be rolled out.""")
 
     run_sp.add_argument("-mrp", "--mask-recipe-prods", action="store", nargs='+',
         help="""If `--recipe-vars` is specified, mask the versions found within the recipe variables YAML

--- a/lib/vars.py
+++ b/lib/vars.py
@@ -174,7 +174,7 @@ ARG_DEFAULTS = {
     "func": "!!python/name:__main__.process_install ''!!python/name:__main__.process_install ''",
     "level": "INFO",
     "limit_managed_rollout": ["Compute"],
-    "limit_management_rollout": ["Management_Worker"],
+    "limit_management_rollout": [],
     "managed_rollout_strategy": "stage",
     "media_host": "ncn-m001",
 }


### PR DESCRIPTION
## Summary and Scope

Limit-management-rollout parameter now accepts management hostnames or HSM role_subrole. The default it now an empty list so that no management nodes will be rebuilt unless it is specifically specified by the --limit-management-rollout argument.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [issue id](issue link)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

