### PR TITLE
CASMINST-6208 release/1.5 change limit-mangement-rollout to default to empty list

### DIFF
--- a/iuf
+++ b/iuf
@@ -707,9 +707,10 @@ def main():
        Defaults to the Compute role.""")
 
     run_sp.add_argument("--limit-management-rollout", action="store", nargs='+',
-        default=["Management_Worker"],
-        help="""Override list used to target specific role_subrole(s) only when rolling out management nodes.
-        Defaults to the Management_Worker role.""")
+        default=[],
+        help="""List used to target specific hostnames or HSM management role_subrole only when rolling 
+        out management nodes. Hostname arguments can only belong to a single node type. For example, 
+        both master and worker hostnames can not be provided at the same time. Defaults to an empty list.""")
 
     run_sp.add_argument("-mrp", "--mask-recipe-prods", action="store", nargs='+',
         help="""If `--recipe-vars` is specified, mask the versions found within the recipe variables YAML

--- a/iuf
+++ b/iuf
@@ -710,7 +710,8 @@ def main():
         default=[],
         help="""List used to target specific hostnames or HSM management role_subrole only when rolling 
         out management nodes. Hostname arguments can only belong to a single node type. For example, 
-        both master and worker hostnames can not be provided at the same time. Defaults to an empty list.""")
+        both master and worker hostnames can not be provided at the same time. Defaults to an empty list
+        which means no nodes will be rolled out.""")
 
     run_sp.add_argument("-mrp", "--mask-recipe-prods", action="store", nargs='+',
         help="""If `--recipe-vars` is specified, mask the versions found within the recipe variables YAML

--- a/lib/vars.py
+++ b/lib/vars.py
@@ -174,7 +174,7 @@ ARG_DEFAULTS = {
     "func": "!!python/name:__main__.process_install ''!!python/name:__main__.process_install ''",
     "level": "INFO",
     "limit_managed_rollout": ["Compute"],
-    "limit_management_rollout": ["Management_Worker"],
+    "limit_management_rollout": [],
     "managed_rollout_strategy": "stage",
     "media_host": "ncn-m001",
 }


### PR DESCRIPTION
## Summary and Scope

Limit-management-rollout parameter now accepts management hostnames or HSM role_subrole. The default it now an empty list so that no management nodes will be rebuilt unless it is specifically specified by the --limit-management-rollout argument.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

