### PR TITLE
Summary: Changes to avoid "TypeError: 'NoneType' object is not iterable" exception during 'iuf list-activities' command

### DIFF
--- a/iuf
+++ b/iuf
@@ -57,6 +57,7 @@ import yaml
 
 install_logger = get_install_logger()
 
+
 def validate_stages(config):
     """Validate that all of the various stage related args passed in are valid"""
 
@@ -69,7 +70,8 @@ def validate_stages(config):
     skip_stages = config.args.get('skip_stages')
     state_dir = config.args.get('state_dir')
 
-    config.stages.validate(state_dir, begin_stage, end_stage, run_stages, skip_stages)
+    config.stages.validate(state_dir, begin_stage,
+                           end_stage, run_stages, skip_stages)
     local_stages = config.stages.get(all_stages=False, list_fmt=True)
     if config.args.get("func", "") not in [process_install]:
         # No need to do all the error checking if we're just calling
@@ -88,7 +90,8 @@ def validate_stages(config):
             if concurrency != None and concurrency < 1:
                 errors.append("`--concurrency` requires at least one thread.")
         except ValueError:
-            errors.append("`--concurrency` requires a positive integer argument.")
+            errors.append(
+                "`--concurrency` requires a positive integer argument.")
 
     bpcd = config.args.get("bootprep_config_dir", None)
     rvars = config.args.get("recipe_vars", None)
@@ -99,7 +102,7 @@ def validate_stages(config):
     # Check if any of the stages requiring site-vars, etc are being called.
     # Further error-checking related to this is done in SiteConfig.
     if any(stage in local_stages for stage in ["update-vcs-config",
-        "update-cfs-config"]):
+                                               "update-cfs-config"]):
         in_bootprep_stage = True
         if not (bpcd or rvars or config.args.get("site_vars", None)):
             errors.append("bootprep or vcs stages were called, but none of "
@@ -126,10 +129,11 @@ def validate_stages(config):
             if os.path.exists(rv_path):
                 config.args["recipe_vars"] = rv_path
             else:
-               warn_or_error(f"{RECIPE_VARS} could not be found in {bpcd}")
+                warn_or_error(f"{RECIPE_VARS} could not be found in {bpcd}")
         if bpc_managed:
             if not os.path.exists(bpc_managed):
-                warn_or_error(f"--bootprep-config-managed {bpc_managed} was specified, but could not be found")
+                warn_or_error(
+                    f"--bootprep-config-managed {bpc_managed} was specified, but could not be found")
             else:
                 found_managed = True
         else:
@@ -142,7 +146,8 @@ def validate_stages(config):
 
         if bpc_management:
             if not os.path.exists(bpc_management):
-                warn_or_error(f"--bootprep-config-management {bpc_management} was specified, but could not be found")
+                warn_or_error(
+                    f"--bootprep-config-management {bpc_management} was specified, but could not be found")
             else:
                 found_management = True
         else:
@@ -150,7 +155,7 @@ def validate_stages(config):
             if os.path.exists(management_path):
                 config.args["bootprep_config_management"] = management_path
                 found_management = True
-            #else:
+            # else:
                 # Issue a warning that the path doesn't exist
                 # warn_or_error(f"{BP_CONFIG_MANAGEMENT} was not found in {os.path.join(bpcd, "bootprep")}")
         if not (found_managed or found_management):
@@ -184,7 +189,7 @@ def validate_stages(config):
         if (bpc_managed or bpc_management) and in_bootprep_stage:
             if not bpc_managed:
                 install_logger.warning("--bootprep-config-managed was specified without --bootprep-config-management.  "
-                "The management images will not be built.")
+                                       "The management images will not be built.")
             elif not bpc_management:
                 install_logger.warning("--bootprep-config-management was specified without "
                                        "--bootprep-config-managed.  The managed images will not be built.")
@@ -198,7 +203,8 @@ def validate_stages(config):
         if mrp_type != "list":
             # This shouldn't happen via the commandline, but can happen when
             # specifying the argument via the input file ('-i/--input-file).
-            errors.append(f"-mrp/--mask-recipe-prods requires a list, but the argument was passed as {mrp_type}")
+            errors.append(
+                f"-mrp/--mask-recipe-prods requires a list, but the argument was passed as {mrp_type}")
 
     got_bootprep_error = False
 
@@ -223,7 +229,8 @@ def validate_stages(config):
             return
         elif not os.path.exists(arg_value):
             got_bootprep_error = True
-            errors.append(f"{param_name} {arg_value} was specified, but the file could not be found")
+            errors.append(
+                f"{param_name} {arg_value} was specified, but the file could not be found")
             return
         arg_val_basename = os.path.basename(arg_value)
         if not media_dir:
@@ -245,7 +252,8 @@ def validate_stages(config):
             got_bootprep_error = True
             return
 
-        new_config_loc = os.path.join(media_dir, f".bootprep-{activity}", arg_val_basename)
+        new_config_loc = os.path.join(
+            media_dir, f".bootprep-{activity}", arg_val_basename)
         if not os.path.exists(new_config_loc):
             os.makedirs(new_config_loc)
 
@@ -255,14 +263,15 @@ def validate_stages(config):
             else:
                 os.remove(new_config_loc)
         if os.path.isdir(arg_value):
-            shutil.copytree(src=arg_value, dst=new_config_loc) # copytree
+            shutil.copytree(src=arg_value, dst=new_config_loc)  # copytree
         else:
             shutil.copy(arg_value, new_config_loc)
 
         # Change the commandline arguments to the new location, relative to media_dir to make things
         # seemless to the user.
         relative_name = f"relative_{arg_name}"
-        config.args[relative_name] = os.path.relpath(new_config_loc, start=media_dir)
+        config.args[relative_name] = os.path.relpath(
+            new_config_loc, start=media_dir)
 
     # Ensure the validity of the `--bootprep-config-dir`,
     # `--bootprep-config-managed`, and `--bootprep-config-managment` arguments.
@@ -297,6 +306,7 @@ def validate_stages(config):
         not be able to write logs or other neccessary files"""
         install_logger.warning(textwrap.dedent(warning_msg))
 
+
 def process_activity(config):
     state = config.args.get("state", None)
     if state:
@@ -313,9 +323,11 @@ def process_activity(config):
             install_logger.error(f"{e}")
             install_logger.debug(traceback.format_exc())
             sys.exit(1)
-    elif config.args.get("create", False) :
-        install_logger.error("The `--create` flag was passed without the <state> positional parameter")
-        install_logger.error("Please include one of the following states: {}".format(", ".join(ACTIVITY_VALID_STATES)))
+    elif config.args.get("create", False):
+        install_logger.error(
+            "The `--create` flag was passed without the <state> positional parameter")
+        install_logger.error("Please include one of the following states: {}".format(
+            ", ".join(ACTIVITY_VALID_STATES)))
         sys.exit(1)
 
     if "activity" in config.args and config.args["activity"]:
@@ -327,20 +339,22 @@ def process_activity(config):
 def process_install(config):
     """Run the install"""
 
-    install_logger.info(f"[ACTIVITY: {config.activity.name:47}] BEG Install started at {config.stages.installer_start}")
+    install_logger.info(
+        f"[ACTIVITY: {config.activity.name:47}] BEG Install started at {config.stages.installer_start}")
     config.activity.create_activity()
     config.activity.run_stages(resume=False)
 
     config.activity.state({"state": "waiting_admin"})
     duration = elapsed_time(config.stages.installer_start)
-    install_logger.info(f"[ACTIVITY: {config.activity.name:47}] END Completed in {duration}")
+    install_logger.info(
+        f"[ACTIVITY: {config.activity.name:47}] END Completed in {duration}")
 
     summary = config.stages.get_summary()
     dashes = "----------------"
     print("{}\n{}\n{}".format(dashes, summary, dashes))
 
 
-def process_list(config): #pylint: disable=unused-argument
+def process_list(config):  # pylint: disable=unused-argument
     """Process the arguments to the list subparser"""
 
     summary = None
@@ -351,9 +365,11 @@ def process_list(config): #pylint: disable=unused-argument
         all_stages = stages.get(long=True, list_fmt=False, status=False)
     else:
         if config.args.get("format", None) == "csv":
-            all_stages = ','.join(config.stages.get(long=True, status=True, all_stages=True, list_fmt=False))
+            all_stages = ','.join(config.stages.get(
+                long=True, status=True, all_stages=True, list_fmt=False))
         else:
-            all_stages = config.stages.get(long=True, status=True, all_stages=True, list_fmt=False)
+            all_stages = config.stages.get(
+                long=True, status=True, all_stages=True, list_fmt=False)
             summary = config.stages.get_summary(load=True)
 
     print(all_stages)
@@ -367,10 +383,12 @@ def process_debug_level(config):
     if config.args.get("level", None):
         if config.args["level"] in LOG_LEVELS.keys():
             level = LOG_LEVELS[config.args["level"]]
-            install_logger_stream_init(level, config.args.get("verbose", False))
+            install_logger_stream_init(
+                level, config.args.get("verbose", False))
         else:
             # when this runs we don't have a logger yet, just print and exit
-            print("ERROR: Unrecognized log level: {}".format(config.args["level"]))
+            print("ERROR: Unrecognized log level: {}".format(
+                config.args["level"]))
             sys.exit(1)
     else:
         install_logger_stream_init(verbose=config.args.get("verbose", False))
@@ -381,6 +399,7 @@ def process_debug_level(config):
         install_logger.info("All logs will be stored in {}".format(log_dir))
     return
 
+
 def get_comment(text_or_list):
     """Take an list or a string and return it as a string."""
     comment = None
@@ -390,6 +409,7 @@ def get_comment(text_or_list):
         comment = text_or_list
 
     return comment
+
 
 def process_resume(config):
     """Resume an activity"""
@@ -409,13 +429,17 @@ def process_abort(config):
 
 def process_list_activity(config):
     activities = lib.Activity.list_activity()
-    print(activities)
+    if len(activities) != 0:
+        print(activities)
+    else:
+        print("No Activities found")
 
 
 def process_workflow(config):
 
     text = config.activity.workflow_info()
     print(text)
+
 
 def update_logger_config(config):
     """
@@ -426,6 +450,7 @@ def update_logger_config(config):
         install_logger.dryrun("Dryrun enabled")
 
     addLoggingLevel('TRACE', logging.DEBUG - 1)
+
 
 def check_environment_variables():
     """
@@ -440,6 +465,7 @@ def check_environment_variables():
         if var in os.environ:
             del os.environ[var]
 
+
 def log_state_files(config):
     if not hasattr(config, "args"):
         return
@@ -448,6 +474,7 @@ def log_state_files(config):
     if hasattr(config, "stages_file"):
         if os.path.exists(config.stages_file):
             shutil.copy2(config.stages_file, logdir)
+
 
 def print_extra_summary(config):
     if not hasattr(config, "args"):
@@ -458,7 +485,7 @@ def print_extra_summary(config):
     log_hints = []
     error_messages = []
     artifacts = []
-    parse_lines = ["INFO","ERR","CRIT"]
+    parse_lines = ["INFO", "ERR", "CRIT"]
 
     if os.path.exists(install_log):
         skip_re = re.compile(r" END \[\d+\] \[Failed\]")
@@ -531,12 +558,15 @@ def initialization(config, args):
     init_errors = []
 
     if not lib.Activity.valid_activity_name(args.activity):
-        init_errors.append(f"Activity {args.activity} invalid. Names must only contain lowercase letters, numbers, periods, and dashes")
+        init_errors.append(
+            f"Activity {args.activity} invalid. Names must only contain lowercase letters, numbers, periods, and dashes")
 
     if len(sys.argv) < 2:
-        init_errors.append("{} requires at least 1 argument".format(sys.argv[0]))
+        init_errors.append(
+            "{} requires at least 1 argument".format(sys.argv[0]))
 
-    config.stages = lib.stages.Stages(stage_dict=STAGE_DICT, state_dir=config.args["state_dir"])
+    config.stages = lib.stages.Stages(
+        stage_dict=STAGE_DICT, state_dir=config.args["state_dir"])
     validate_stages(config)
 
     atexit.register(log_state_files, config)
@@ -556,21 +586,22 @@ def get_answer():
         answer = "Invalid"
     return answer
 
+
 # Interrupt variables
 already_answered = False
 answer_text = None
 mypid = os.getpid()
+
 
 def main():
     """Main entry point."""
     check_environment_variables()
     config = lib.Config.Config()
 
-    parser = argparse.ArgumentParser(description=
-        """
+    parser = argparse.ArgumentParser(description="""
        The CSM Install and Upgrade Framework (IUF) CLI.
         """
-    )
+                                     )
 
     parser.add_argument("-i", "--input-file", action="store", help="""YAML input
         file used to provide arguments to `iuf`. Command line arguments will
@@ -578,16 +609,16 @@ def main():
         Can also be set via the IUF_INPUT_FILE environment variable.""")
 
     parser.add_argument("-w", "--write-input-file", action="store_true",
-        help="""Create an input file for iuf populated with the command line
+                        help="""Create an input file for iuf populated with the command line
         options specified and exit.  This input file can be specified with
         the `-i` option on subsequent runs.  Using an input file simplifies
         iuf commands with many options.  Note that the general iuf command
         does not change; so for a long iuf command, add this flag to the
         command to write the input file.""")
 
-    ### TODO, make default value product_vars.yaml 'recipe', fallback to pwd
+    # TODO, make default value product_vars.yaml 'recipe', fallback to pwd
     parser.add_argument("-a", "--activity", action="store",
-        help="""Activity name.  Must be a unique identifier.
+                        help="""Activity name.  Must be a unique identifier.
         Activity names must contain only lowercase letters (a-z), numbers (0-9), periods (.), and dashes (-).
         Can also be set via the IUF_ACTIVITY environment variable.""")
 
@@ -595,39 +626,40 @@ def main():
         By default up to 10 steps will be executed simultaneously.  Use `--concurrency N`
         to decrease the limit to N.   Increasing this limit is not recommended."""
     parser.add_argument("-c", "--concurrency", action="store", default=None,
-        help=concurrency_help)
+                        help=concurrency_help)
 
     parser.add_argument("-b", "--base-dir", action="store",
-        help="""Base directory for state and log file directories. Defaults to ${RBD_BASE_DIR}/iuf/[activity], where ${RBD_BASE_DIR} is /etc/cray/upgrade/csm.""")
+                        help="""Base directory for state and log file directories. Defaults to ${RBD_BASE_DIR}/iuf/[activity], where ${RBD_BASE_DIR} is /etc/cray/upgrade/csm.""")
 
     parser.add_argument("-s", "--state-dir", action="store",
-        help="A directory used to store the current state of stages, used by `iuf` but primarily not of interest to users. Defaults to [base-dir]/state.")
+                        help="A directory used to store the current state of stages, used by `iuf` but primarily not of interest to users. Defaults to [base-dir]/state.")
 
-    #### TODO handle both directories or list of files
+    # TODO handle both directories or list of files
     parser.add_argument("-m", "--media-dir", action="store",
-        help="""Location of installation media to be used. Defaults to ${RBD_BASE_DIR}/[activity],
+                        help="""Location of installation media to be used. Defaults to ${RBD_BASE_DIR}/[activity],
         where ${RBD_BASE_DIR} is /etc/cray/upgrade/csm. `iuf` cannot access installation media
         outside of ${RBD_BASE_DIR}, however input files provided by other `iuf` arguments can exist
         outside of ${RBD_BASE_DIR}.""")
 
     # Host to extract the media onto. Defaults to ncn-m001.
     parser.add_argument("-mh", "--media-host", action="store",
-        help=argparse.SUPPRESS, default="ncn-m001")
+                        help=argparse.SUPPRESS, default="ncn-m001")
 
     parser.add_argument("--log-dir", action="store",
-        help="Location used to store log files. Defaults to [base-dir]/log.")
+                        help="Location used to store log files. Defaults to [base-dir]/log.")
 
     # hide DRYRUN for now until it's production ready
-    parser.add_argument("--dryrun", action=InvertableArgument, default=False, help=argparse.SUPPRESS)
+    parser.add_argument("--dryrun", action=InvertableArgument,
+                        default=False, help=argparse.SUPPRESS)
 
     levelhelp = list(LOG_LEVELS.keys())
     levelhelp.remove('DRYRUN')
     parser.add_argument("-l", "--level", action="store", default='INFO',
-        help="""Set the log message level that determines what is displayed on `iuf` standard output.
+                        help="""Set the log message level that determines what is displayed on `iuf` standard output.
         Messages of this level or higher are displayed.""", choices=levelhelp)
 
     parser.add_argument("-v", "--verbose", action="store_true",
-        help=argparse.SUPPRESS)
+                        help=argparse.SUPPRESS)
 
     # TODO: The stage-dir usage could use more verbiage. We might want to add
     # this to the install docs.  Describing it in detail in the help section
@@ -635,43 +667,45 @@ def main():
     # are fully independent; for example, we have an unpack stage, and an
     # install stage.  The install stage needs to install what was unpacked.
 
-    subparsers = parser.add_subparsers(title="subcommands", metavar='{run,activity,list-stages|ls,resume,restart,abort,list-activities|la,workflow}')
+    subparsers = parser.add_subparsers(
+        title="subcommands", metavar='{run,activity,list-stages|ls,resume,restart,abort,list-activities|la,workflow}')
     stage_list = lib.stages.get_stage_help()
 
     run_sp = subparsers.add_parser("run", description='Run IUF stages to execute install, upgrade and/or deploy operations for a given activity.',
-        epilog="Valid stages:\n{}".format(stage_list),
-        formatter_class=argparse.RawTextHelpFormatter)
+                                   epilog="Valid stages:\n{}".format(
+                                       stage_list),
+                                   formatter_class=argparse.RawTextHelpFormatter)
 
     run_sp.add_argument("-b", "--begin-stage", action="store",
-        help="The first stage to execute. Defaults to process-media")
+                        help="The first stage to execute. Defaults to process-media")
 
     run_sp.add_argument("-e", "--end-stage", action="store",
-        help="The last stage to execute.  Defaults to post-install-check")
+                        help="The last stage to execute.  Defaults to post-install-check")
 
     run_sp.add_argument("-r", "--run-stages", nargs="+", action="store",
-        help="Run the specified stages only. This argument is not compatible with `-b`, `-e`, or `-s`.")
+                        help="Run the specified stages only. This argument is not compatible with `-b`, `-e`, or `-s`.")
 
     run_sp.add_argument("-s", "--skip-stages", nargs="+", action="store",
-        help="Skip the execution of the specified stages.")
+                        help="Skip the execution of the specified stages.")
 
     run_sp.add_argument("-f", "--force", action="store_true", default=False,
-        help="Force re-execution of stage operations.")
+                        help="Force re-execution of stage operations.")
 
     run_sp.add_argument("-bc", "--bootprep-config-managed", action="store",
-        help="""`sat bootprep` config file for managed (compute and
+                        help="""`sat bootprep` config file for managed (compute and
         application) nodes.  Note the path is relative to $PWD, unless an
         absolute path is specified.  Omit this argument to skip building the
         managed images (and ensure the `--bootprep-config-dir` option is not
         specified).""")
 
     run_sp.add_argument("-bm", "--bootprep-config-management", action="store",
-        help="""`sat bootprep` config file for management NCNs.  Note the
+                        help="""`sat bootprep` config file for management NCNs.  Note the
         path is relative to $PWD, unless an absolute path is specified. Omit
         this argument to skip building the management images (and ensure the
         `--bootprep-config-dir` option is not specified).""")
 
     run_sp.add_argument("-bpcd", "--bootprep-config-dir", action="store",
-        help="""Directory containing HPE `product_vars.yaml` and
+                        help="""Directory containing HPE `product_vars.yaml` and
         `sat bootprep` configuration files. The expected content is:
             $(BOOTPREP_CONFIG_DIR)/product_vars.yaml
             $(BOOTPREP_CONFIG_DIR)/bootprep/compute-and-uan-bootprep.yaml
@@ -679,91 +713,109 @@ def main():
         Note the path is relative to $PWD, unless an absolute path is specified.""")
 
     run_sp.add_argument("-rv", "--recipe-vars", action="store",
-        help="""Path to a recipe variables YAML file. HPE provides the
+                        help="""Path to a recipe variables YAML file. HPE provides the
         `product_vars.yaml` recipe variables file with each release. Note
         the path is relative to $PWD, unless an absolute path is specified.""")
 
     run_sp.add_argument("-sv", "--site-vars", action="store", default=False,
-        help="""Path to a site variables YAML file. This file allows the user to override values defined in
+                        help="""Path to a site variables YAML file. This file allows the user to override values defined in
         the recipe variables YAML file. Defaults to ${RBD_BASE_DIR}/${IUF_ACTIVITY}/site_vars.yaml.
         Note the path is relative to $PWD, unless an absolute path is specified.""")
 
     run_sp.add_argument("-mrs", "--managed-rollout-strategy", action="store",
-        choices=["reboot", "stage"],
-        default="stage",
-        help="""Method to update the managed nodes. Accepted values are 'reboot' (reboot nodes _now_) or
+                        choices=["reboot", "stage"],
+                        default="stage",
+                        help="""Method to update the managed nodes. Accepted values are 'reboot' (reboot nodes _now_) or
         'stage' (set up nodes to reboot into new image after next WLM job). Defaults to 'stage'.""")
 
     run_sp.add_argument("-cmrp", "--concurrent-management-rollout-percentage",
-        action="store", default=20, type=int,
-        help="""Limit the number of management nodes that roll out
+                        action="store", default=20, type=int,
+                        help="""Limit the number of management nodes that roll out
         concurrently based on the percentage specified. Must be an integer
         between 1-100. Defaults to 20 (percent).""")
 
     run_sp.add_argument("--limit-managed-rollout", action="store",
-            nargs='+', default=["Compute"],
-       help="""Override list used to target specific nodes only when rolling out
+                        nargs='+', default=["Compute"],
+                        help="""Override list used to target specific nodes only when rolling out
        managed nodes.  Arguments should be xnames or HSM node groups.
        Defaults to the Compute role.""")
 
     run_sp.add_argument("--limit-management-rollout", action="store", nargs='+',
-        default=[],
-        help="""List used to target specific hostnames or HSM management role_subrole only when rolling 
+                        default=[],
+                        help="""List used to target specific hostnames or HSM management role_subrole only when rolling 
         out management nodes. Hostname arguments can only belong to a single node type. For example, 
         both master and worker hostnames can not be provided at the same time. Defaults to an empty list
         which means no nodes will be rolled out.""")
 
     run_sp.add_argument("-mrp", "--mask-recipe-prods", action="store", nargs='+',
-        help="""If `--recipe-vars` is specified, mask the versions found within the recipe variables YAML
+                        help="""If `--recipe-vars` is specified, mask the versions found within the recipe variables YAML
         file for the specified products, such that the largest version of the package already installed on
         the system (found in the product catalog) is used instead of the version supplied in the HPC CSM
         Software Recipe. Note that the versions found via `--site-vars` (or the versions being installed)
         will override it as well.""")
 
-    run_sp.set_defaults(func=process_install, skip_stages=list(), run_stages=list())
+    run_sp.set_defaults(func=process_install,
+                        skip_stages=list(), run_stages=list())
 
-    list_sp = subparsers.add_parser("list-stages", description='List IUF stage information and status for a given activity specified via `-a`.', aliases=["ls"])
+    list_sp = subparsers.add_parser(
+        "list-stages", description='List IUF stage information and status for a given activity specified via `-a`.', aliases=["ls"])
     list_sp.set_defaults(func=process_list)
 
-    resume_sp = subparsers.add_parser("resume", description='Resume a previously aborted or failed IUF session for a given activity.')
+    resume_sp = subparsers.add_parser(
+        "resume", description='Resume a previously aborted or failed IUF session for a given activity.')
     resume_sp.set_defaults(func=process_resume)
-    resume_sp.add_argument("comment", action="store", nargs="*", help="Add a comment to the activity log")
+    resume_sp.add_argument("comment", action="store",
+                           nargs="*", help="Add a comment to the activity log")
 
-    restart_sp = subparsers.add_parser("restart", description='Restart a previously aborted or failed IUF session for a given activity.')
+    restart_sp = subparsers.add_parser(
+        "restart", description='Restart a previously aborted or failed IUF session for a given activity.')
     restart_sp.set_defaults(func=process_restart)
     restart_sp.add_argument("-f", "--force", action="store_true",
-        help="""Force all operations to be re-executed irrespective if they
+                            help="""Force all operations to be re-executed irrespective if they
         have been successful in the past.""")
-    restart_sp.add_argument("comment", action="store", nargs="*", help="Add a comment to the activity log")
+    restart_sp.add_argument("comment", action="store",
+                            nargs="*", help="Add a comment to the activity log")
 
-    abort_sp = subparsers.add_parser("abort", description='Abort an IUF session for a given activity immediately or after the current stage completes.')
+    abort_sp = subparsers.add_parser(
+        "abort", description='Abort an IUF session for a given activity immediately or after the current stage completes.')
     abort_sp.set_defaults(func=process_abort)
 
     # help for the comment flag should be something like,
     # """Adds a comment to the "Comment" row if the `iuf activity ...` table.
     # The option is hidden because it doesn't seem to be working in the backend.
-    abort_sp.add_argument("comment", action="store", nargs="*", help="Add a comment to the activity log")
+    abort_sp.add_argument("comment", action="store",
+                          nargs="*", help="Add a comment to the activity log")
 
     abort_sp.add_argument("-f", "--force", action="store_true",
-        help="""Force the abort immediately.""")
+                          help="""Force the abort immediately.""")
 
-    activity_sp = subparsers.add_parser("activity", description='Create, display, or annotate activity information.')
-    activity_sp.add_argument("--time", help="A time value used when creating or modifying an activity entry. Must match an existing time value to modify that entry. Defaults to now.", action="store")
-    activity_sp.add_argument("--create", help="Create a new activity entry.", action="store_true", default=False)
-    activity_sp.add_argument("--comment", help="A comment to be associated with an activity entry.", action="store")
-    activity_sp.add_argument("--status", help="A status value to be associated with an activity entry.", action="store", default="n/a", choices=lib.Activity.ACTIVITY_VALID_STATUS)
-    activity_sp.add_argument("--argo-workflow-id", help="An Argo workflow identifier to be associated with an activity entry.", default=None)
-    activity_sp.add_argument("state", nargs="?", help="activity state value", action="store", default=None, choices=lib.Activity.ACTIVITY_VALID_STATES)
+    activity_sp = subparsers.add_parser(
+        "activity", description='Create, display, or annotate activity information.')
+    activity_sp.add_argument(
+        "--time", help="A time value used when creating or modifying an activity entry. Must match an existing time value to modify that entry. Defaults to now.", action="store")
+    activity_sp.add_argument(
+        "--create", help="Create a new activity entry.", action="store_true", default=False)
+    activity_sp.add_argument(
+        "--comment", help="A comment to be associated with an activity entry.", action="store")
+    activity_sp.add_argument("--status", help="A status value to be associated with an activity entry.",
+                             action="store", default="n/a", choices=lib.Activity.ACTIVITY_VALID_STATUS)
+    activity_sp.add_argument(
+        "--argo-workflow-id", help="An Argo workflow identifier to be associated with an activity entry.", default=None)
+    activity_sp.add_argument("state", nargs="?", help="activity state value",
+                             action="store", default=None, choices=lib.Activity.ACTIVITY_VALID_STATES)
 
     activity_sp.set_defaults(func=process_activity)
 
     list_activity_sp = subparsers.add_parser("list-activities",
-        description="List all IUF activities stored in argo.", aliases=["la"])
+                                             description="List all IUF activities stored in argo.", aliases=["la"])
     list_activity_sp.set_defaults(func=process_list_activity)
 
-    workflow_sp = subparsers.add_parser("workflow", description="List workflows or information for a particular workflow")
-    workflow_sp.add_argument("workflows", action="store", help="workflow to look up", nargs="*")
-    workflow_sp.add_argument("--debug", "-d", action="store_true", help="Give more granular details about the workflow")
+    workflow_sp = subparsers.add_parser(
+        "workflow", description="List workflows or information for a particular workflow")
+    workflow_sp.add_argument("workflows", action="store",
+                             help="workflow to look up", nargs="*")
+    workflow_sp.add_argument("--debug", "-d", action="store_true",
+                             help="Give more granular details about the workflow")
     workflow_sp.set_defaults(func=process_workflow)
 
     # create a config object to store all of the configured options in the parser
@@ -779,7 +831,7 @@ def main():
     tmp_vars = vars(parser.parse_args())
 
     # load any defaults from the input file
-    configfile.set_defaults(parser,tmp_vars)
+    configfile.set_defaults(parser, tmp_vars)
 
     if tmp_vars["write_input_file"]:
         configfile.write(tmp_vars)
@@ -845,7 +897,8 @@ def main():
             if not already_answered:
                 already_answered = True
                 config.activity.abort_activity(background_only=True)
-                print(f"Use `{script_name} -a {activity} resume` to re-connect")
+                print(
+                    f"Use `{script_name} -a {activity} resume` to re-connect")
                 print("Bye!")
 
         elif answer in ["f", "force"]:
@@ -873,6 +926,7 @@ def main():
     except Exception as e:
         install_logger.error("An unexpected error occurred: {}".format(e))
         raise
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary and Scope

When there are no Activities created yet in IUF, 'iuf list-activities' encounters an exception.
ncn-m001:~ # iuf list-activities
An unexpected error occurred: 'NoneType' object is not iterable
Traceback (most recent call last):
  File "iuf", line 878, in <module>
  File "iuf", line 866, in main
  File "iuf", line 411, in process_list_activity
  File "lib/Activity.py", line 94, in list_activity
TypeError: 'NoneType' object is not iterable
[50326] Failed to execute script 'iuf' due to unhandled exception!

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_
Not Applicable

## Issues and Related PRs
Not Applicable

* Resolves [33496] https://jira-pro.it.hpe.com:8443/browse/CAST-33496

## Testing

Tested on development system with no activities and multiple activities.

### Tested on:

  * `#mug, #surtur`

### Test description:

- Run 'iuf list-activities' on a cluster where there are no activities done yet.
- Run 'iuf list-activities' on a cluster where there are multiple activities executed/in execution.


## Risks and Mitigations

None

## Pull Request Checklist

- [1.5.4] Version number(s) incremented, if applicable
- [NA] Copyrights updated
- [Yes] License file intact
- [Yes] Target branch correct
- [NA] CHANGELOG.md updated
- [Yes] Testing is appropriate and complete, if applicable
- [NA] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
