### PR TITLE
CASM: iuf-cli generates TypeError: 'NoneType' object is not iterable exception when there are no activities to list

### DIFF
--- a/iuf
+++ b/iuf
@@ -409,7 +409,10 @@ def process_abort(config):
 
 def process_list_activity(config):
     activities = lib.Activity.list_activity()
-    print(activities)
+    if len(activities) > 0:
+        print(activities)
+    else:
+        print("No Activities found")
 
 
 def process_workflow(config):

--- a/lib/Activity.py
+++ b/lib/Activity.py
@@ -89,10 +89,13 @@ def list_activity():
     List an activity.  This is done outside the activity class so
     a user can list activities without having to specify an activity.
     """
+    act_list = []
     api = lib.ApiInterface.ApiInterface()
-    activities = api.get_activities().json()
-    act_list = sorted([act["name"] for act in activities])
-
+    if api is not None:
+        activities = api.get_activities().json()
+        if activities is not None:
+            act_list = sorted([act["name"] for act in activities])
+   
     return "\n".join(act_list)
 
 


### PR DESCRIPTION
## Summary and Scope

When there are no Activities created yet in IUF, 'iuf list-activities' encounters an exception.
ncn-m001:~ # iuf list-activities
An unexpected error occurred: 'NoneType' object is not iterable
Traceback (most recent call last):
  File "iuf", line 878, in <module>
  File "iuf", line 866, in main
  File "iuf", line 411, in process_list_activity
  File "lib/Activity.py", line 94, in list_activity
TypeError: 'NoneType' object is not iterable
[50326] Failed to execute script 'iuf' due to unhandled exception!

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_
Not Applicable

## Issues and Related PRs
Not Applicable

* Resolves [33496] https://jira-pro.it.hpe.com:8443/browse/CAST-33496
* Resolves [4478] https://jira-pro.it.hpe.com:8443/browse/CASM-4498
## Testing

Tested on development system with no activities and multiple activities.

### Tested on:

  * `#mug, #surtur`

### Test description:

- Run 'iuf list-activities' on a cluster where there are no activities done yet.
- Run 'iuf list-activities' on a cluster where there are multiple activities executed/in execution.


## Risks and Mitigations

None

## Pull Request Checklist

- [1.5.4] Version number(s) incremented, if applicable
- [NA] Copyrights updated
- [Yes] License file intact
- [Yes] Target branch correct
- [NA] CHANGELOG.md updated
- [Yes] Testing is appropriate and complete, if applicable
- [NA] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable