### PR TITLE
CASMTRIAGE-5798-release/1.5 stop recursion error when copying IUF bootprep dir

### DIFF
--- a/iuf
+++ b/iuf
@@ -255,7 +255,8 @@ def validate_stages(config):
             else:
                 os.remove(new_config_loc)
         if os.path.isdir(arg_value):
-            shutil.copytree(src=arg_value, dst=new_config_loc) # copytree
+            # copytree, ignore statement is to stop possible recurssion error
+            shutil.copytree(src=arg_value, dst=new_config_loc, ignore=shutil.ignore_patterns(f".bootprep-{activity}"))
         else:
             shutil.copy(arg_value, new_config_loc)
 


### PR DESCRIPTION
## Summary and Scope
CASMTRIAGE-5798 When running IUF, the bootprep dir is copied into a subdirectory named .bootprep-${activity} inside the media directory. If the media directory is the same as the bootprep directory supplied then there is a recursion error. This error is hit because the .../media-dir/.bootprep-${activity} dir keeps getting copied into the .bootprep-${activity} dir. This change ignores that directory when copying the contents of the directory.

## Issues and Related PRs

* Resolves CASMTRIAGE_5798

## Testing

This was tested on Fanta, a CSM 1.5 system.
Test 1 - use original version of iuf-cli. Supply same bootprep and media dir. Observed recursion error.
Test 2 - use PR's version of iuf-cli. Supply same bootprep and media dir. No recurssion error and files were correctly copied files to .bootprep-${activity} dir.
Test 3 - use PR's version of iuf-cli. Supply different bootprep and media dir. No recurssion error and files were correctly copied files to .bootprep-${activity} dir.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

