### PR TITLE
CASMPET-6760-release/1.5 fix podname so IUF-CLI can get pod logs

### DIFF
--- a/lib/Activity.py
+++ b/lib/Activity.py
@@ -665,14 +665,20 @@ class Activity():
                         pass
 
                 if "type" in node and node["type"] == "Pod":
-                    podname = node["id"]
+                    node_id = node["id"]
+                    podname = node_id
+                    try:
+                        if "templateRef" in node.keys() and "template" in node["templateRef"].keys():
+                            node_id_splits = node_id.rsplit('-',1)
+                            podname = node_id_splits[0] + "-" + node["templateRef"]["template"] + "-" + node_id_splits[1]
+                    except:
+                        pass
                     if podname not in followed_pods:
                         followed_pods.append(podname)
                         for container in ["init", "wait", "main"]:
                             proc = multiprocessing.Process(target=self.podlogs.follow_pod_log, args=(podname, container, log_prefix, self.st_event))
                             proc.start()
                             self.running_procs.append(proc)
-
                 if "displayName" in node:
                     if name not in phases:
                         phases[name] = newphase.copy()

--- a/lib/Activity.py
+++ b/lib/Activity.py
@@ -666,11 +666,16 @@ class Activity():
 
                 if "type" in node and node["type"] == "Pod":
                     node_id = node["id"]
-                    podname = node_id
+                    podname = ""
                     try:
-                        if "templateRef" in node.keys() and "template" in node["templateRef"].keys():
-                            node_id_splits = node_id.rsplit('-',1)
-                            podname = node_id_splits[0] + "-" + node["templateRef"]["template"] + "-" + node_id_splits[1]
+                          template = ""
+                          node_id_splits = node_id.rsplit('-',1)
+                          if "templateName" in node.keys():
+                              template = node["templateName"]
+                          elif "templateRef" in node.keys() and "template" in node["templateRef"].keys():
+                              template =  node["templateRef"]["template"]
+                          ## no need for an else statement, the pod name will have two '--' if the keys are not present
+                          podname = node_id_splits[0] + "-" + template + "-" + node_id_splits[1]
                     except:
                         pass
                     if podname not in followed_pods:


### PR DESCRIPTION
## Summary and Scope

This issue was the result of a logging change made in the IUF-CLI. The IUF-CLI previously would follow all logs of pods in the 'argo' namespace. However, this was a but of a race condition and it was possible to miss logs. The logging was changed to follow logs by pod name. However, the pod name that was being used was incorrect so no logs were found. The PRs for this ticket will correct the name of the pod so that logs are found. 

Originally, the IUF-CLI would be looking for logs from a pod with the name 
```lindsaytest-bfdgb-management-nodes-rollout-957q5-1528568188```. 
But the actual pod name would be 
```lindsaytest-bfdgb-management-nodes-rollout-957q5-record-time-template-1528568188```. The template needs to be added to the pod name.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-6760](https://jira-pro.it.hpe.com:8443/browse/CASMPET-6760)
*  Resolves [CASMINST-6618]( https://jira-pro.it.hpe.com:8443/browse/CASMINST-6618)

## Testing

### Tested on:

  * Mug

### Test description:

- Observed issue existed in iuf-cli rpm versions 1.5.X and 1.6.X.
- Installed updated iuf-cli rpm and saw the below logging result.

```bash
...
INFO [INFO-to-read                                             ] BEG INFO-to-read(0)
INFO [INFO-to-read                                             ]       This workflow will rollout worker nodes according to --limit-management-rollout parameter.
INFO [INFO-to-read                                             ]       This stage will start an additional Argo workflow whose name contains 'ncn-lifecycle-rebuild'. Check for this workflow in the Argo UI.
INFO [INFO-to-read                                             ]       Check the argo pod logs from each step in the workflow to see what the step is doing
INFO [INFO-to-read                                             ] END INFO-to-read [Succeeded]
INFO [INFO-to-read                                             ] END INFO-to-read(0) [Succeeded]
INFO [verify-worker-images-and-configuration                   ] BEG verify-worker-images-and-configuration
INFO [verify-worker-images-and-configuration.verify-images-and-] BEG verify-images-and-configs
INFO [verify-worker-images-and-configuration.verify-images-and-] BEG verify-images-and-configs(0)
ERR  [verify-worker-images-and-configuration.verify-images-and-]       No CFS configuration was received for 'Management_Worker' from 'prepare-images' stage. Retry by running from 'prepare-images' stage
ERR  [verify-worker-images-and-configuration.verify-images-and-] END verify-images-and-configs(0) [Failed] 
...
```

```bash
ncn-m001:/etc/cray/upgrade/csm/iuf/lindsaytest/log/20230907143607/argo_logs # cat lindsaytest-65hmd-management-nodes-rollout-zbwxp-shell-script-739750467-main.txt
2023-09-07T14:37:29.995706564Z DEBUG capturing logs
2023-09-07T14:37:30.066809895Z Warning: Permanently added 'ncn-m001' (ED25519) to the list of known hosts.
2023-09-07T14:37:30.569245281Z Warning: Permanently added 'ncn-m001' (ED25519) to the list of known hosts.
2023-09-07T14:37:31.152171095Z jq: error (at <stdin>:1): Cannot iterate over null (null)
2023-09-07T14:37:31.155105740Z ERROR No CFS configuration was received for 'Management_Worker' from 'prepare-images' stage. Retry by running from 'prepare-images' stage
2023-09-07T14:37:31.161037022Z Error: exit status 1 
```

## Risks and Mitigations

This is a low risk change. I do want to note that it is possible this change does not capture all pod logs if the pod name does not conform the pattern here. It needs to be watched when all IUF steps are done, whether or not all pods are correctly followed by this change.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

