### PR TITLE
CASMTRIAGE-6164 fix Warning message when bootprep file is not specified for managed or management

### DIFF
--- a/iuf.py
+++ b/iuf.py
@@ -183,11 +183,11 @@ def validate_stages(config):
     else:
         if (bpc_managed or bpc_management) and in_bootprep_stage:
             if not bpc_managed:
-                install_logger.warning("--bootprep-config-managed was specified without --bootprep-config-management.  "
-                "The management images will not be built.")
-            elif not bpc_management:
                 install_logger.warning("--bootprep-config-management was specified without "
                                        "--bootprep-config-managed.  The managed images will not be built.")
+            elif not bpc_management:
+                install_logger.warning("--bootprep-config-managed was specified without --bootprep-config-management.  "
+                                       "The management images will not be built.")
         elif not (bpc_managed or bpc_management) and in_bootprep_stage:
             err_msg = formatted("""A bootprep stage was specified, but neither --bootprep-config-management
             nor --bootprep-config-managed were specified.""")


### PR DESCRIPTION
## Summary and Scope

IUF-cli had the incorrect output when a management or managed bootprep file was not provided. The warning message would state that the opposite file was missing. For example, when the **managed-bootprep** file was provided, the warning message said that **managed** images would not be built.
```bash
ncn-m001:/etc/cray/upgrade/csm/leliasen # iuf -a lindsayclitest -m /etc/cray/upgrade/csm/leliasen run -r update-cfs-config -bc /etc/cray/upgrade/csm/atif/csm-test-admin/bootprep/compute-and-uan-bootprep.yaml
INFO All logs will be stored in /etc/cray/upgrade/csm/iuf/lindsayclitest/log/20231025152147
WARN --bootprep-config-management was specified without --bootprep-config-managed.  The managed images will not be built.
```

This PR fixes the warning message.
The following is output from the fixed iuf-cli when **managed-bootprep** is provided.
```bash
iuf -a lindsayclitest -m /etc/cray/upgrade/csm/leliasen run -r update-cfs-config -bc /etc/cray/upgrade/csm/atif/csm-test-admin/bootprep/compute-and-uan-bootprep.yaml
INFO All logs will be stored in /etc/cray/upgrade/csm/iuf/lindsayclitest/log/20231025152803
WARN --bootprep-config-managed was specified without --bootprep-config-management.  The management images will not be built.
```
The following is output from the fixed iuf-cli when **management-bootprep** is provided.
```bash
iuf -a lindsayclitest -m /etc/cray/upgrade/csm/leliasen run -r update-cfs-config -bm /etc/cray/upgrade/csm/atif/csm-test-admin/bootprep/management-bootprep.yaml
INFO All logs will be stored in /etc/cray/upgrade/csm/iuf/lindsayclitest/log/20231025152916
WARN --bootprep-config-management was specified without --bootprep-config-managed.  The managed images will not be built.
```
## Issues and Related PRs

* Resolves [CASMTRIAGE-6164](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6164)

## Testing

### Tested on:

  * Mug - CSM 1.5
  
### Test description:

- Observed error on iuf-cli on mug.
- Installed fixed iuf-cli and saw that the error had been resolved.


## Risks and Mitigations

Low risk.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

