### PR TITLE
CASMTRIAGE-6256 IUF output has incorrect log paths

### DIFF
--- a/lib/Activity.py
+++ b/lib/Activity.py
@@ -722,8 +722,11 @@ class Activity():
                                     s3 = artifact["s3"]["key"]
                                     phases[name]["log"] = s3
                                     dname_s3 = f"{dname}: {s3}"
+                                    timestamp= self.config.timestamp
+                                    logdir=self.config.args.get("log_dir")
+                                    file_name = s3.split("/")[-2]
                                     if dname_s3 not in printed_s3:
-                                        self.config.logger.debug(f"{log_prefix} LOG FILE FOR {dname_s3}")
+                                        self.config.logger.debug(f"{log_prefix} LOG FILE FOR {dname}: {logdir}/{timestamp}/argo_logs/{file_name}-main.txt")
                                         printed_s3[dname_s3] = True
                         except:
                             pass


### PR DESCRIPTION
## Summary and Scope

The path for the argo logs has been changed. It has been made into an absolute path .
This was a bug fix.

## Issues and Related PRs

Associated JIRA link - https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6256

## Testing

The changes have been tested . And the log directory has been verified to be present on the system.
### Tested on:

  * #mug

### Test description:

The new log path was added in lib/Activity.py , the resulted iuf-cli rpm was installed on mug and using IUF cpe installation was ran till process-media. 
After the run, using the log path  install.log the file was verified to be present with correct contents.

The jenkins build ran successfully.
Since this was a bug fix no new test issues/Jiras were created .



## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

