### PR TITLE
CASMTRIAGE-6413  Bad error message from iuf cli

### DIFF
--- a/iuf.py
+++ b/iuf.py
@@ -227,10 +227,10 @@ def validate_stages(config):
             return
         arg_val_basename = os.path.basename(arg_value)
         if not media_dir:
-            err_msg = "A media directory was not "
-            "found and was not specified while "
-            "running a bootprep stage.  It must be a subdirectory under "
-            f"{config.media_base_dir}.  Was process-media ran?"
+            err_msg = f"""A media directory was not 
+            found and was not specified while 
+            running a bootprep stage.  It must be a subdirectory under 
+            {config.media_base_dir}.  Was process-media ran?"""
             warn_or_error(err_msg, non_bp_suppress=True)
             got_bootprep_error = True
             return
@@ -238,9 +238,9 @@ def validate_stages(config):
         elif media_dir and not os.path.exists(media_dir):
             # The media directory is necessary during the bootprep stage
             # because bootprep files are copied to the media directory.
-            err_msg = f"`{arg_name} {arg_value}` was specified, but "
-            "`-m/--media-dir` does not exist.  The "
-            "media directory is necessary during the bootprep stages. "
+            err_msg = f"""`{arg_name} {arg_value}` was specified, but 
+            `-m/--media-dir` does not exist.  The 
+            media directory is necessary during the bootprep stages. """
             warn_or_error(err_msg, non_bp_suppress=True)
             got_bootprep_error = True
             return


### PR DESCRIPTION
## Summary and Scope

This is a bug fix for CASMTRIAGE-6413 . The error message was getting truncated since multi-line messages were not enclosed in triple quotes.
This change is backward compatible.

## Issues and Related PRs

* https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6413

## Testing



### Tested on:

  * mug 


### Test description:

Reproduced a similar error in process-media stage by printing some dummy multi-line messages without triple quotes.
The messages were observed to be truncated.
After adding the triple quotes, the messages got printed as intended. 

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_
No.


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

