### PR TITLE
CASMTRIAGE-6716

### DIFF
--- a/lib/stages.py
+++ b/lib/stages.py
@@ -333,22 +333,23 @@ class Stages():
             install_logger.critical("occurred while executing %s", stage)
 
         if failed:
-            session_json = config.activity.api.get_activity_session(config.activity.name, sessionid).json()
-            current_state = session_json["current_state"]
-            if current_state not in ["in_progress", "transitioning"]:
-                print("")
-                install_logger.info("Aborting install after %s", elapsed_time(self.installer_start))
-                print("")
-                self.stage_hist.update(stage, ran=False, succeeded="Paused",duration=duration)
-                # update the current state with the failure
-                config.activity.state({"timestamp": utime, "status":"Failed"})
-                # put the whole process into debug
-                config.activity.state({"state":"debug"})
+            while True:
+                session_json = config.activity.api.get_activity_session(config.activity.name, sessionid).json()
+                current_state = session_json["current_state"]
+                if current_state not in ["in_progress", "transitioning"]:
+                    print("")
+                    install_logger.info("Aborting install after %s", elapsed_time(self.installer_start))
+                    print("")
+                    self.stage_hist.update(stage, ran=False, succeeded="Paused",duration=duration)
+                    # update the current state with the failure
+                    config.activity.state({"timestamp": utime, "status":"Failed"})
+                    # put the whole process into debug
+                    config.activity.state({"state":"debug"})
 
-                print(self.get_summary())
-                sys.exit(1)
-            else:
-                install_logger.error(f"The {stage} stage failed, but argo must run to the completion of the stage.")
+                    print(self.get_summary())
+                    sys.exit(1)
+                else:
+                    install_logger.error(f"The {stage} stage failed, but argo must run to the completion of the stage.")
         else:
             config.activity.state({"timestamp":utime, "status":"Succeeded"})
             self.stage_hist.update(stage, True, True, duration=duration)

--- a/lib/stages.py
+++ b/lib/stages.py
@@ -349,7 +349,8 @@ class Stages():
                     print(self.get_summary())
                     sys.exit(1)
                 else:
-                    install_logger.error(f"The {stage} stage failed, but argo must run to the completion of the stage.")
+                    install_logger.warn(f"The {stage} stage failed, but argo must run to the completion of the stage.")
+                    time.sleep(1)
         else:
             config.activity.state({"timestamp":utime, "status":"Succeeded"})
             self.stage_hist.update(stage, True, True, duration=duration)


### PR DESCRIPTION
## Summary and Scope

This is a bug fix for CASMTRIAGE-6716 . iuf not exiting with an error when failed.
Giving message "The stage failed, but argo must run to the completion of the stage." 
But not exitng after stage completion.

## Issues and Related PRs

* https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6716

## Testing



### Tested on:

  * beau 


### Test description:

Reproduced a similar error in deliver-product stage by running installation of cos 2.5.103 and added a while loop to monitor until argo ran until completion of stage and sys.exit(1) after stage completion.


## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_
No.


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

