### PR TITLE
iuf not exiting with an error when failed

### DIFF
--- a/lib/Activity.py
+++ b/lib/Activity.py
@@ -503,7 +503,7 @@ class Activity():
                     self.config.logger.warning(f"Still waiting for workflow startup after {count} seconds.")
                 time.sleep(1)
 
-        return retflow
+        return retflow,status
 
     def sort_phases(self, workflow, nodes):
 
@@ -1050,9 +1050,11 @@ class Activity():
 
     def watch_next_wf(self, sessionid):
         while True:
-            wfid = self.get_next_workflow(sessionid)
+            wfid,session_status = self.get_next_workflow(sessionid)
             if not wfid:
                 self.config.logger.debug(f"No more workflows found for session {sessionid}.")
+                if session_status == "debug":
+                    sys.exit(1)
                 break
             self.config.logger.debug("Next workflow {}".format(wfid))
             wf = self.get_workflow(wfid)

--- a/lib/stages.py
+++ b/lib/stages.py
@@ -348,7 +348,7 @@ class Stages():
                 print(self.get_summary())
                 sys.exit(1)
             else:
-                install_logger.error(f"The {stage} stage failed, but argo must run to the completion of the stage.")
+                install_logger.warn(f"The {stage} stage failed, but argo must run to the completion of the stage.")
         else:
             config.activity.state({"timestamp":utime, "status":"Succeeded"})
             self.stage_hist.update(stage, True, True, duration=duration)


### PR DESCRIPTION
## Summary and Scope

This is a bug fix for CASMTRIAGE-6716 . iuf not exiting with an error when failed.
Giving message "The stage failed, but argo must run to the completion of the stage." 
But not exitng after stage completion.

## Issues and Related PRs

* https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6716
* https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6554

## Testing



### Tested on:

  * beau 


### Test description:

Reproduced a similar error in deliver-product stage by running installation of cos 2.5.103 .

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_
No.


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

