### PR TITLE
CASMTRIAGE-6813 iuf-cli should not look for product manifest if docs tar file

### DIFF
--- a/lib/Activity.py
+++ b/lib/Activity.py
@@ -1116,7 +1116,7 @@ class Activity():
                             Tar file {product} found in media directory
                             was not extracted into a new directory.
                             Some files were extracted into the media
-                            directory. Assuming this is a Docs tarfile
+                            directory. Assuming this is not an IUF product tarfile
                             and IUF will not look for 'iuf-product-manifest.yaml'""")
                         self.config.logger.warning(file_tar_msg)
                         break

--- a/lib/Activity.py
+++ b/lib/Activity.py
@@ -1108,6 +1108,19 @@ class Activity():
                 if tar_path and os.path.exists(tar_path):
                     # The path exists and process_media has been run.  Note
                     # the directory will not exist before process-media is ran.
+                    if os.path.isfile(tar_path):
+                        # All files in the tar file was not extracted into a new directory.
+                        # Files were extracted to the media dir.
+                        # Assuming this is a Docs tar file.
+                        file_tar_msg = formatted(f"""
+                            Tar file {product} found in media directory
+                            was not extracted into a new directory.
+                            Some files were extracted into the media
+                            directory. Assuming this is a Docs tarfile
+                            and IUF will not look for 'iuf-product-manifest.yaml'""")
+                        self.config.logger.warning(file_tar_msg)
+                        break
+                        
                     dir_contents = os.listdir(tar_path)
                     if "iuf-product-manifest.yaml" in dir_contents:
                         matches = [cp for cp in cfgmap_locs if cp == tar_path]


### PR DESCRIPTION
## Summary and Scope

Once a product has been extracted with IUF, the IUF-CLI looks in the extracted directory for the iuf-product-manifest.yaml file. However, when a Docs file is extracted, like slingshot-docs-2.1.2.tar.gz, an error can be hit because it tries to list the files in the extracted directory. However, there are extracted files that are not in a directory and IUF hits an error because it tries to list files on this file. To fix this, I added a check to see if files were extracted from the tarball and not a directory. If it is files, then IUF skips looking for the iuf-product-manifest.yaml because it assumes the tar file was a docs tar file.

Note: we don't usually see this because docs tar files are not usually put in the IUF media directory and I would recommend they be put in a different directory.

## Testing

I tested this on Wasp.
I reproduced the error with iuf-cli 1.5.11-1.

```
iuf -a le-cli-test -m /etc/cray/upgrade/csm/media/le-test-docs     run --site-vars /etc/cray/upgrade/csm/admin/site_vars.yaml --recipe-vars /etc/cray/upgrade/csm/admin/product_vars.yaml     -b process-media -e deliver-product
INFO All logs will be stored in /etc/cray/upgrade/csm/iuf/le-cli-test/log/20240325204349
INFO [ACTIVITY: le-cli-test                                    ] BEG Install started at 2024-03-25 20:43:49.214604
INFO [IUF SESSION: le-cli-test-986vx                           ] BEG Started at 2024-03-25 20:43:51.004321
ERR  An unexpected error occurred: [Errno 20] Not a directory: '/etc/cray/upgrade/csm/media/le-test-docs/Slingshot_Hardware_Guide.pdf'
Traceback (most recent call last):
  File "iuf.py", line 879, in <module>
  File "iuf.py", line 867, in main
  File "iuf.py", line 333, in process_install
  File "lib/Activity.py", line 917, in run_stages
  File "lib/Activity.py", line 1148, in run_stage
  File "lib/Activity.py", line 1111, in watch_next_wf
NotADirectoryError: [Errno 20] Not a directory: '/etc/cray/upgrade/csm/media/le-test-docs/Slingshot_Hardware_Guide.pdf'
[3325026] Failed to execute script 'iuf' due to unhandled exception!

Error Summary:
   An unexpected error occurred: [Errno 20] Not a directory: '/etc/cray/upgrade/csm/media/le-test-docs/Slingshot_Hardware_Guide.pdf'
```
When I put the edited version of the IUF CLI on wasp. I got the following output.

```
iuf -a le-cli-test -m /etc/cray/upgrade/csm/media/le-test-docs     run --site-vars /etc/cray/upgrade/csm/admin/site_vars.yaml --recipe-vars /etc/cray/upgrade/csm/admin/product_vars.yaml     -b process-media -e deliver-product
INFO All logs will be stored in /etc/cray/upgrade/csm/iuf/le-cli-test/log/20240325204619
INFO [ACTIVITY: le-cli-test                                    ] BEG Install started at 2024-03-25 20:46:19.057695
INFO [IUF SESSION: le-cli-test-3uvuc                           ] BEG Started at 2024-03-25 20:46:19.910312
WARN Tar file slingshot-docs-2.1.2.tar.gz found in media directory was not
extracted into a new directory. Some files were extracted into the media
directory. Assuming this is a Docs tarfile and IUF will not look for
'iuf-product-manifest.yaml'
INFO [STAGE: process-media                                     ] BEG Argo workflow: le-cli-test-3uvuc-process-media-7jt5n
INFO [extract-release-distributions                            ] BEG extract-release-distributions
INFO [extract-release-distributions                            ] BEG start-operation
INFO [extract-release-distributions                            ] END start-operation [Succeeded]
INFO [extract-release-distributions                            ] BEG list-tar-files
INFO [extract-release-distributions                            ] END list-tar-files [Succeeded]
INFO [extract-tar-files                                        ] BEG extract-tar-files
INFO [extract-tar-files(0:slingshot-docs-2.1.2.tar.gz)         ] BEG extract-tar-files(0:slingshot-docs-2.1.2.tar.gz)
INFO [extract-tar-files(1:uan-2.6.2.tar.gz)                    ] BEG extract-tar-files(1:uan-2.6.2.tar.gz)
INFO [extract-tar-files(0:slingshot-docs-2.1.2.tar.gz)         ] END extract-tar-files(0:slingshot-docs-2.1.2.tar.gz) [Succeeded]
INFO [extract-tar-files                                        ] END extract-tar-files [Succeeded]
INFO [extract-release-distributions                            ] BEG end-operation
INFO [extract-tar-files(1:uan-2.6.2.tar.gz)                    ] END extract-tar-files(1:uan-2.6.2.tar.gz) [Succeeded]
INFO [extract-release-distributions                            ] END end-operation [Succeeded]
INFO [extract-release-distributions                            ] BEG prom-metrics
INFO [extract-release-distributions                            ] END extract-release-distributions [Succeeded]
INFO [extract-release-distributions                            ] END prom-metrics [Succeeded]
INFO [STAGE: process-media                                     ] END Succeeded in 0:01:42
INFO [IUF SESSION: le-cli-test-3uvuc                           ] END Completed at 2024-03-25 20:48:04.410428
INFO [IUF SESSION: le-cli-test-b0gyk                           ] BEG Started at 2024-03-25 20:48:04.674620
WARN Tar file slingshot-docs-2.1.2.tar.gz found in media directory was not
extracted into a new directory. Some files were extracted into the media
directory. Assuming this is a Docs tarfile and IUF will not look for
'iuf-product-manifest.yaml'
INFO [STAGE: pre-install-check                                 ] BEG Argo workflow: le-cli-test-b0gyk-pre-install-check-2sv27
INFO [preflight-checks-for-services                            ] BEG preflight-checks-for-services
INFO [preflight-checks-for-services                            ] BEG start-operation
INFO [preflight-checks-for-services                            ] END start-operation [Succeeded]
INFO [preflight-checks-for-services                            ] BEG preflight-checks
INFO [preflight-checks-for-services                            ] BEG preflight-checks(0)
INFO [preflight-checks-for-services                            ]       s3 is operational.
INFO [preflight-checks-for-services                            ]       CFS is operational.
INFO [preflight-checks-for-services                            ]       VCS is operational.
INFO [preflight-checks-for-services                            ]       IMS is operational.
INFO [preflight-checks-for-services                            ]       Nexus is operational.
INFO [preflight-checks-for-services                            ]       Cray Product Catalog configmap exists.
INFO [preflight-checks-for-services                            ] END preflight-checks [Succeeded]
INFO [preflight-checks-for-services                            ] END preflight-checks(0) [Succeeded]
INFO [preflight-checks-for-services                            ] BEG end-operation
INFO [preflight-checks-for-services                            ] END end-operation [Succeeded]
INFO [preflight-checks-for-services                            ] BEG prom-metrics
INFO [preflight-checks-for-services                            ] END preflight-checks-for-services [Succeeded]
INFO [preflight-checks-for-services                            ] END prom-metrics [Succeeded]
INFO [STAGE: pre-install-check                                 ] END Succeeded in 0:00:50
WARN Tar file slingshot-docs-2.1.2.tar.gz found in media directory was not
extracted into a new directory. Some files were extracted into the media
directory. Assuming this is a Docs tarfile and IUF will not look for
'iuf-product-manifest.yaml'
INFO [STAGE: deliver-product                                   ] BEG Argo workflow: le-cli-test-b0gyk-deliver-product-vwx8l
INFO [uan-2-6-2-add-product-to-product-catalog                 ] BEG uan-2-6-2-add-product-to-product-catalog-a9fsx
INFO [uan-2-6-2-add-product-to-product-catalog                 ] BEG start-operation
INFO [uan-2-6-2-add-product-to-product-catalog                 ] END start-operation [Succeeded]
INFO [uan-2-6-2-add-product-to-product-catalog                 ] BEG update-product-catalog
INFO [uan-2-6-2-add-product-to-product-catalog                 ]       Updating config_map=cray-product-catalog in namespace=services for product/version=uan/2.6.2
...
```


## Issues and Related PRs

* Resolves [CASMTRIAGE-6813](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6813)

## Risks and Mitigations

This change assumes product tar files always extract all of their files into a new directory.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

