### PR TITLE
CASM-4703

### DIFF
--- a/lib/Activity.py
+++ b/lib/Activity.py
@@ -614,6 +614,10 @@ class Activity():
         while not finished:
             try:
                 wflow = self.get_workflow(workflow)
+                if wflow is None:
+                    self.config.logger.debug(f"Workflow {workflow} not found.")
+                    finished = True  # Set finished to True to break from the loop
+                    break
             except Exception as e:
                 self.config.logger.debug(f"Unable to get workflow {workflow}: {e}")
 
@@ -656,7 +660,7 @@ class Activity():
             This will be used only for those stages which have an onExit in the spec.
             '''
             # checking if onExit handler is present for the workflow
-            if "onExit" in wflow["spec"]:
+            if wflow and "onExit" in wflow["spec"]:
                 if wflow["spec"]["onExit"] == "onExitHandlers" and not onExitPod:
                     if type(nodes) is dict:
                         for node, nDetail in nodes.items():

--- a/lib/Activity.py
+++ b/lib/Activity.py
@@ -615,8 +615,8 @@ class Activity():
             try:
                 wflow = self.get_workflow(workflow)
                 if wflow is None:
-                    self.config.logger.debug(f"Workflow {workflow} not found.")
-                    finished = True  # Set finished to True to break from the loop
+                    self.config.logger.error(f"Workflow {workflow} not found.")
+                    finished = True  
                     break
             except Exception as e:
                 self.config.logger.debug(f"Unable to get workflow {workflow}: {e}")


### PR DESCRIPTION
## Summary and Scope

During the reboot of m001 in management-nodes-rollout stage , the cli got the workflow 'None' but this error was not handled . In case of workflow of 'None' type no further execution in monitor workflow is required.
Hence adding this check for the workflow(wflow)  after get_workflow function.

## Issues and Related PRs

* Resolves [CASM-4703](https://jira-pro.it.hpe.com:8443/browse/CASM-4703)


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

