### PR TITLE
CASMTRIAGE-6947 :stage_hist update for partial workflows

### DIFF
--- a/lib/Activity.py
+++ b/lib/Activity.py
@@ -1084,6 +1084,8 @@ class Activity():
         return "\n".join(return_text)
 
     def watch_next_wf(self, sessionid):
+        prev_stage=""
+        is_partial= False
         while True:
             wfid,session_status = self.get_next_workflow(sessionid)
             if not wfid:
@@ -1096,6 +1098,10 @@ class Activity():
             if not wf:
                 break
             stage = wf['metadata']['labels']['stage']
+            #  updating the is_partial flag for partial workflows
+            if prev_stage == stage:
+                is_partial= True
+            prev_stage=stage
             self.site_conf.update_dict_stack(stage)
 
             # Dump the session/workflow information for debugging purposes.
@@ -1182,7 +1188,7 @@ class Activity():
                             to be re-ran?""")
                         self.config.logger.debug(new_tar_msg)
             # Run the stage.
-            self.config.stages.exec_stage(self.config, wfid, sessionid, stage)
+            self.config.stages.exec_stage(self.config, wfid, sessionid, stage, is_partial)
 
     def run_stage(self, payload):
         try:


### PR DESCRIPTION
## Summary and Scope

This was a bug fix caused due to partial workflows. An extra flag has been added to see if the current workflow is a partial workflow of a stage. If so, the status of the stage is being updated accordingly.

## Issues and Related PRs

* Resolves [CASMTRIAGE-6947](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6947)

### Tested on:

  * starlord

### Test description:

deliver-product stage was ran with 14 products to create 4 partial workflows. 

- 1st partial workflow- Succeeded
- 2nd partial workflow- Failed
- 3rd partial workflow- Succeeded
- 4th partial workflow- Succeeded

The status of the stage was not updated to "Succeeded".

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

