### PR TITLE
CASMTRIAGE-6934: CSM IUF fails to restart management-nodes-rollout stage with key error after pre-hook failed

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -74,6 +74,7 @@ pipeline {
                 environment {
                     DOCKER_ARCH = sh(returnStdout: true, script: "[ ${ARCH} == 'x86_64' ] && echo -n 'amd64' || echo -n 'arm64'")
                     BUILD_DIR = "${env.WORKSPACE}/dist/rpmbuild/${ARCH}/"
+                    PIP_EXTRA_INDEX_URL="https://arti.hpc.amslabs.hpecorp.net:443/artifactory/csm-python-modules-remote/simple/"
                 }
 
                 stages {

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ export PYTHON_VERSION := 3.10
 endif
 
 export PYTHON_BIN := python$(PYTHON_VERSION)
+export PIP_EXTRA_INDEX_URL=https://arti.hpc.amslabs.hpecorp.net:443/artifactory/csm-python-modules-remote/simple/
 
 ifeq ($(VERSION),)
 export VERSION := $(shell python3 -m setuptools_scm 2>/dev/null | tr -s '-' '~' | sed 's/^v//')

--- a/iuf-cli.spec
+++ b/iuf-cli.spec
@@ -52,7 +52,7 @@ Framework API.
 %install
 %python_exec -m pip install -U -r requirements.txt
 
-pyinstaller --onefile iuf.py -p iuf
+pyinstaller --onefile --collect-data cray_product_catalog iuf.py -p iuf
 
 install -m 755 -D dist/iuf %{buildroot}%{_bindir}/iuf
 

--- a/lib/InstallerUtils.py
+++ b/lib/InstallerUtils.py
@@ -30,6 +30,7 @@ import json
 import textwrap
 import yaml
 import prettytable
+from semver import Version
 
 from lib.InstallLogger import get_install_logger
 from cray_product_catalog.query import ProductCatalog
@@ -43,7 +44,7 @@ def highestVersion(versions_list):
         try:
             parsed_versions.append(Version.parse(version))
         except ValueError:
-            install_logger.debug("Found invalid version: %s", version)
+            install_logger.debug("Ignoring invalid version: %s", version)
     sorted_vs = sorted(parsed_versions)
     if not sorted_vs:
         return ''
@@ -88,8 +89,8 @@ def get_product_catalog(config, all_products=False):
     # kubectl command won't give the full catalog data because of the split of cray-product-catalog. 
     # cray-product-catalog has ProductCatalog class which combines all the product configmaps .
     if not config.all_product_data:
-        product_cat= ProductCatalog()
-        all_product_data= product_cat.products
+        product_cat = ProductCatalog()
+        all_product_data = product_cat.products
         config.all_product_data = all_product_data
     else:
         all_product_data = config.all_product_data

--- a/lib/SiteConfig.py
+++ b/lib/SiteConfig.py
@@ -36,7 +36,7 @@ import textwrap
 
 from lib.vars import RECIPE_VARS, BP_CONFIG_MANAGED, BP_CONFIG_MANAGEMENT, SESSION_VARS, MEDIA_VERSIONS, UnexpectedState
 
-from lib.InstallerUtils import get_product_catalog, formatted
+from lib.InstallerUtils import get_product_catalog, formatted, highestVersion
 
 from lib.InstallLogger import get_install_logger
 
@@ -61,18 +61,6 @@ def read_yaml(file_loc):
         sys.exit(1)
 
     return return_dict
-
-def highestVersion(versions_list):
-    parsed_versions = []
-    for version in versions_list:
-        try:
-            parsed_versions.append(Version.parse(version))
-        except ValueError:
-            install_logger.debug("Found invalid version: %s", version)
-    sorted_vs = sorted(parsed_versions)
-    if not sorted_vs:
-        return ''
-    return str(sorted_vs[-1])
 
 class SiteConfig():
     def __init__(self, config):
@@ -112,9 +100,7 @@ class SiteConfig():
         # Get the product catalog as the base layer.
         full_product_catalog = get_product_catalog(config, all_products=True)
         for prod in full_product_catalog:
-            versions = [elt for elt in list(full_product_catalog[prod].keys()) if elt]
-
-            self.product_catalog[prod] = {"version": highestVersion(versions)}
+            self.product_catalog[prod['name']] = {"version": prod['version']}
 
         recipe_vars_file = config.args.get("recipe_vars", None)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,6 @@ PyYAML==6.0.1
 python-keycloak==2.15.3
 requests >= 2.31.0, < 3.0
 semver >= 3.0.1, < 4.0
+cray_product_catalog == 2.3.0
+jsonschema
+urllib3


### PR DESCRIPTION
## Summary and Scope

The latest cray-product-catalog splits the main configmap into product specific catalogs. Hence "kubectl" command used for cray-product-catalog won't give all the data.
This fix imports the cray-product-catalog module and leverages ProductCatalog class which will have all the combined data of the configmaps .

## Issues and Related PRs

* Resolves [CASMTRIAGE-6934](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6934) , [CASM-4729](https://jira-pro.it.hpe.com:8443/browse/CASM-4729)
* https://github.com/Cray-HPE/cray-product-catalog/pull/325

### Tested on:

  * starlord

### Test description:

IUF was ran till management-nodes-rollout .

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

