### PR TITLE
CASMTRIAGE-7168 : Iuf abort with no args generates a python traceback

### DIFF
--- a/iuf.py
+++ b/iuf.py
@@ -802,7 +802,7 @@ def main():
         parser.print_help(sys.stderr)
         sys.exit(1)
 
-    if not args.activity and hasattr(args, "func") and args.func in [process_install, process_workflow]:
+    if not args.activity and hasattr(args, "func") and args.func in [process_install, process_workflow, process_abort]:
         print("ERROR: --activity is required.")
         parser.print_help(sys.stderr)
         sys.exit(1)


### PR DESCRIPTION
## Summary and Scope

iuf abort command needs an activity to be specified. This fix will handle the scenario if the activity is not provided rather than giving traceback error.

## Issues and Related PRs

* Resolves [CASMTRIAGE-7168](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7168)`

### Tested on:

  * starlord

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

