### PR TITLE
CASMTRIAGE-7134 :get_workflow api integration

### DIFF
--- a/lib/Activity.py
+++ b/lib/Activity.py
@@ -148,6 +148,7 @@ class Activity():
         self.podlogs = PodLogs(config, self.name)
 
         self.api = lib.ApiInterface.ApiInterface()
+        self.nlsapi = lib.ApiInterface.ApiInterface(resource="/nls/v1")
         self.workflows = []
 
     def __repr__(self):
@@ -810,12 +811,13 @@ class Activity():
 
     def get_workflow(self, workflow):
         try:
-            wf = self.config.connection.run(f"kubectl -n argo get Workflow/{workflow} -o yaml")
+            ret_code = self.nlsapi.get_workflow(workflow)
+            wf = ret_code.json()
         except Exception as e:
             self.config.logger.debug(f"Unable to get workflow {workflow}: {e}")
             return None
 
-        return yaml.safe_load(wf.stdout)
+        return wf
 
     def abort_activity(self, background_only=False):
         """Abort an activity."""

--- a/lib/ApiInterface.py
+++ b/lib/ApiInterface.py
@@ -156,3 +156,10 @@ class ApiInterface(object):
         except:
             raise
 
+    def get_workflow(self,workflow):
+        api_path = f"/workflows/{workflow}"
+        try:
+            api_response = self.request("GET", api_path)
+            return api_response
+        except:
+            raise


### PR DESCRIPTION
## Summary and Scope

To get the workflow information instead of using kubectl command , nls API is being used now .  PR is for release 1.6.1

## Issues and Related PRs

* Resolves [CASMTRIAGE-7134](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7134)
* https://github.com/Cray-HPE/cray-nls/pull/218

## Testing

ran process-media multiple times

### Tested on:

  * `mug`

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

