### PR TITLE
CASMTRIAGE-7823 :management-nodes-rollout failed with 503

### DIFF
--- a/lib/Activity.py
+++ b/lib/Activity.py
@@ -119,7 +119,7 @@ class Activity():
     def __init__(self, filename=None, name=None, dryrun=False, config=None):
         self.states = dict()
         
-        self.nlsapi = lib.ApiInterface.ApiInterface(resource="/nls/v1")
+        self.nlsapi = lib.ApiInterface.ApiInterface(resource="/nls/v1") # needs to be initialized before load_activity_dict call
         self.dryrun = dryrun
         self.filename = filename
         self.site_conf = None

--- a/lib/Activity.py
+++ b/lib/Activity.py
@@ -110,6 +110,7 @@ class Activity():
     filename = None
     auth = None
     api = None
+    nlsapi = None
     workflows = None
     api_initialized = False
     st_event = None
@@ -117,7 +118,8 @@ class Activity():
 
     def __init__(self, filename=None, name=None, dryrun=False, config=None):
         self.states = dict()
-
+        
+        self.nlsapi = lib.ApiInterface.ApiInterface(resource="/nls/v1")
         self.dryrun = dryrun
         self.filename = filename
         self.site_conf = None
@@ -149,7 +151,6 @@ class Activity():
         self.podlogs = PodLogs(config, self.name)
 
         self.api = lib.ApiInterface.ApiInterface()
-        self.nlsapi = lib.ApiInterface.ApiInterface(resource="/nls/v1")
         self.workflows = []
 
     def __repr__(self):
@@ -925,14 +926,22 @@ class Activity():
         return stat
 
     def get_workflow(self, workflow):
-        try:
-            ret_code = self.nlsapi.get_workflow(workflow)
-            wf = ret_code.json()
-        except Exception as e:
-            self.config.logger.debug(f"Unable to get workflow {workflow}: {e}")
-            return None
+        retries = 10
+        delay = 10  # seconds
 
-        return wf
+        for attempt in range(retries):
+            try:
+                ret_code = self.nlsapi.get_workflow(workflow)
+                if ret_code.status_code == 200:
+                    wf = ret_code.json()
+                    return wf
+            except Exception as e:
+                self.config.logger.debug(f"Unable to get workflow {workflow}: {e} ")
+                
+            if attempt < retries :
+                self.config.logger.warning(f"Unable to get workflow status. Retrying after {delay} seconds...")
+                time.sleep(delay)
+        return None
 
     def abort_activity(self, background_only=False):
         """Abort an activity."""


### PR DESCRIPTION
## Summary and Scope

During management-nodes-rollout the nls API calls might fail due to restarts and charts upgrade.
We have added a retry for nls API call to get_workflow, in case api call fails to give time for restarts . 

Also moved initialization of nlsapi before calling load_activity_dict which internally calls get_workflow.

## Issues and Related PRs

* Resolves [CASMTRIAGE-7823](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7823)

### Tested on:

  * starlord

### Test description:

While process-media was running, nls pods were scaled down which resulted iuf-cli to get **" 503 Server Error: Service Unavailable for url"** error. 
the pods were scaled up while IUF was retrying every 10 seconds to get_workflow. Once the pods were up the nls API call was successful and cli was able to show the session logs on the terminal
Screenshots added in the JIRA. 

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

