### PR TITLE
CASMINST-7104 Add --set-management-config , --set-management-image pa…

### DIFF
--- a/iuf.py
+++ b/iuf.py
@@ -3,7 +3,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -705,6 +705,12 @@ def main():
         default="stage",
         help="""Method to update the managed nodes. Accepted values are 'reboot' (reboot nodes _now_) or
         'stage' (set up nodes to reboot into new image after next WLM job). Defaults to 'stage'.""")
+
+    run_sp.add_argument("-mnrs", "--management-rollout-strategy", action="store",
+        choices=["reboot", "rebuild"],
+        default="rebuild",
+        help="""Method to rollout the management nodes. Accepted values are 'reboot' or
+        'rebuild'. Defaults to 'rebuild'.""")
 
     run_sp.add_argument("-cmrp", "--concurrent-management-rollout-percentage",
         action="store", default=20, type=int,

--- a/iuf.py
+++ b/iuf.py
@@ -725,6 +725,16 @@ def main():
         both master and worker hostnames can not be provided at the same time. Defaults to an empty list
         which means no nodes will be rolled out.""")
 
+    run_sp.add_argument("-smi", "--set-management-image", action="store",
+        default=None,
+        help="""Method to pass user defined management image only when rolling
+        out management nodes.""")
+
+    run_sp.add_argument("-smc", "--set-management-config", action="store",
+        default=None,
+        help="""Method to pass user defined management config only when rolling
+        out management nodes.""")
+
     run_sp.add_argument("-mrp", "--mask-recipe-prods", action="store", nargs='+',
         help="""If `--recipe-vars` is specified, mask the versions found within the recipe variables YAML
         file for the specified products, such that the largest version of the package already installed on

--- a/lib/Activity.py
+++ b/lib/Activity.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -1089,6 +1089,11 @@ class Activity():
         if "management-nodes-rollout" in stages:
             boot_image_management = self.config.args.get("set_management_image")
             cfs_configuration_management = self.config.args.get("set_management_config")
+            management_rollout_strat = self.config.args.get("management_rollout_strategy", None)
+
+            if management_rollout_strat:
+                payload["input_parameters"]["management_rollout_strategy"] = management_rollout_strat
+
             if ((boot_image_management is not None) and (cfs_configuration_management is not None)):
                 try:
                     self.config.connection.run(f"cray cfs v3 configurations describe {cfs_configuration_management}")

--- a/lib/Activity.py
+++ b/lib/Activity.py
@@ -45,7 +45,7 @@ import lib.ApiInterface
 from lib.PodLogs import PodLogs
 from lib.SiteConfig import SiteConfig
 from lib.InstallerUtils import formatted, format_column
-from lib.vars import ARG_DEFAULTS
+from lib.vars import ARG_DEFAULTS, RunException
 
 class StateError(Exception):
     """A wrapper for raising a StateError exception."""
@@ -1085,6 +1085,31 @@ class Activity():
         rollout_percentage = self.config.args.get("concurrent_management_rollout_percentage")
         if rollout_percentage:
            payload["input_parameters"]["concurrent_management_rollout_percentage"] = rollout_percentage
+
+        if "management-nodes-rollout" in stages:
+            boot_image_management = self.config.args.get("set_management_image")
+            cfs_configuration_management = self.config.args.get("set_management_config")
+            if ((boot_image_management is not None) and (cfs_configuration_management is not None)):
+                try:
+                    self.config.connection.run(f"cray cfs v3 configurations describe {cfs_configuration_management}")
+                    self.config.logger.debug(f"Found CFS configuration: {cfs_configuration_management}")
+                except RunException as e:
+                    self.config.logger.error(f"Could not find the desired configuration {cfs_configuration_management}")
+                    self.config.logger.debug(f"Command <cray cfs v3 configurations describe {cfs_configuration_management} produced -\n\n{e.stderr}")
+                    sys.exit(1)
+                try:
+                    self.config.connection.run(f"cray ims images describe {boot_image_management}")
+                    self.config.logger.debug(f"Found image: {boot_image_management} in IMS for Management node rebuild")
+                except RunException as e:
+                    self.config.logger.error(f"Could not find the required image {boot_image_management} in IMS for Management node rebuild")
+                    self.config.logger.debug(f"Command <cray ims images describe {boot_image_management}> produced -\n\n{e.stderr}")
+                    sys.exit(1)
+                payload["input_parameters"]["cfs_configuration_management"] = cfs_configuration_management
+                payload["input_parameters"]["boot_image_management"] = boot_image_management
+            elif ((boot_image_management is not None) or (cfs_configuration_management is not None)) :
+                #check only if boot_image_management or cfs_configuration_management and raise attribute error only anyone is passed
+                self.config.logger.error("--set-management-image and --set-management-config both must be passed together in management-nodes-rollout")
+                sys.exit(1)
 
         sessions = []
 


### PR DESCRIPTION
## Summary and Scope

Adding two cli parameters for management-nodes-rollout stage to enable passing an image and configuration for the rebuild.

## Issues and Related PRs

* Resolves [CASMINST-7104](https://jira-pro.it.hpe.com:8443/browse/CASMINST-7104)
* https://github.com/Cray-HPE/cray-nls/pull/227
* https://github.com/Cray-HPE/docs-csm/pull/5953

## Testing

Rebuild of w003 made with both passing the new parameters and without them

### Tested on:

  * starlord


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

