### PR TITLE
CAST-37291: adding default for site_vars

### DIFF
--- a/iuf.py
+++ b/iuf.py
@@ -694,9 +694,10 @@ def main():
         `product_vars.yaml` recipe variables file with each release. Note
         the path is relative to $PWD, unless an absolute path is specified.""")
 
-    run_sp.add_argument("-sv", "--site-vars", action="store", default=False,
+    run_sp.add_argument("-sv", "--site-vars", action="store", default=None,
         help="""Path to a site variables YAML file. This file allows the user to override values defined in
-        the recipe variables YAML file. Defaults to ${RBD_BASE_DIR}/${IUF_ACTIVITY}/site_vars.yaml.
+        the recipe variables YAML file. Defaults to ${RBD_BASE_DIR}/${IUF_ACTIVITY}/site_vars.yaml if it exists,
+        otherwise defaults to ${RBD_BASE_DIR}/site_vars.yaml.
         Note the path is relative to $PWD, unless an absolute path is specified.""")
 
     run_sp.add_argument("-mrs", "--managed-rollout-strategy", action="store",

--- a/lib/SiteConfig.py
+++ b/lib/SiteConfig.py
@@ -34,7 +34,7 @@ from semver import Version
 import shutil
 import textwrap
 
-from lib.vars import RECIPE_VARS, BP_CONFIG_MANAGED, BP_CONFIG_MANAGEMENT, SESSION_VARS, MEDIA_VERSIONS, UnexpectedState
+from lib.vars import RECIPE_VARS, BP_CONFIG_MANAGED, BP_CONFIG_MANAGEMENT, SESSION_VARS, MEDIA_VERSIONS, UnexpectedState, RBD_BASE_DIR
 
 from lib.InstallerUtils import get_product_catalog, formatted, highestVersion
 
@@ -105,6 +105,18 @@ class SiteConfig():
         recipe_vars_file = config.args.get("recipe_vars", None)
 
         site_vars_file = config.args.get("site_vars", None)
+
+        if site_vars_file is None:
+            activity = config.args.get("activity")
+
+            first_path = os.path.join(RBD_BASE_DIR, activity, 'site_vars.yaml')
+            second_path = os.path.join(RBD_BASE_DIR, 'site_vars.yaml')
+            if os.path.exists(first_path):
+                install_logger.debug("Using the default path for --site-vars {}".format(first_path))
+                site_vars_file = first_path
+            elif os.path.exists(second_path):
+                install_logger.debug("Using the default path for --site-vars {}".format(second_path))
+                site_vars_file = second_path
         tmp_mask = config.args.get("mask_recipe_prods", [])
         if tmp_mask:
             self.mask_recipe_prods = tmp_mask


### PR DESCRIPTION
## Summary and Scope

Adding default path for site_vars to be used in the below order -

1. ${RBD_BASE_DIR}/${IUF_ACTIVITY}/site_vars.yaml
2. If (1) doesn't exist, then ${RBD_BASE_DIR}/site_vars.yaml.


## Issues and Related PRs

* Resolves [CAST-37291](https://jira-pro.it.hpe.com:8443/browse/CAST-37291)

## Testing

Testing done and updated on SPIRA
https://spiraplan-pro-ext.it.hpe.com/SpiraPlan/3714/TestCase/List.aspx

### Tested on:

  * starlord

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

