### PR TITLE
CASM-5599 : skip workflow with Unknown status

### DIFF
--- a/lib/Activity.py
+++ b/lib/Activity.py
@@ -465,6 +465,13 @@ class Activity():
                         if attr in state:
                             # Update any sessions that don't have a finished state
                             if attr == "status" and state[attr] not in ["Succeeded","Failed", "restart", "resume", "abort"]:
+                                if state[attr] == "Unknown":
+                                    workflow = state["workflow_id"]
+                                    wf = self.config.connection.run(f"kubectl -n argo get Workflow/{workflow} -o yaml --ignore-not-found")
+                                    if not wf.stdout:
+                                        self.config.logger.debug(f"workflow {workflow} has an Unknown status and does not exist, skipping getting the status.")
+                                        self.states[stime][attr] = "Unknown"
+                                        continue
                                 if state.get("workflow_id", None):
                                     state['status'], last_finished = self.get_workflow_status(state["workflow_id"])
                             self.states[stime][attr] = state[attr]

--- a/lib/Activity.py
+++ b/lib/Activity.py
@@ -465,6 +465,7 @@ class Activity():
                         if attr in state:
                             # Update any sessions that don't have a finished state
                             if attr == "status" and state[attr] not in ["Succeeded","Failed", "restart", "resume", "abort"]:
+                                # In certain scenarios, workflow might end up with an Unknown status due to nls restart
                                 if state[attr] == "Unknown":
                                     workflow = state["workflow_id"]
                                     wf = self.config.connection.run(f"kubectl -n argo get Workflow/{workflow} -o yaml --ignore-not-found")


### PR DESCRIPTION
## Summary and Scope

If any workflow has Unknown status , IUF tries to get the status and update it in the state file when any new run using that activity is triggered, Rather than waiting 10 mins in a loop for getting the status, now cli will perform a check using kubectl to see if the workflow exists or not.
If not, then IUF leaves the Unknown status as is and moves on.

## Issues and Related PRs

* Resolves [CASM-5599](https://jira-pro.it.hpe.com:8443/browse/CASM-5599) 
* [CASMTRIAGE-7926](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7926)

### Tested on:

  * starlord

### Test description:

Tests updated on Spira - https://spiraplan-pro-ext.it.hpe.com/SpiraPlan/3714/TestCase/List.aspx

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

