### PR TITLE
CASMTRIAGE-8020 : fix split WARN for float

### DIFF
--- a/lib/SiteConfig.py
+++ b/lib/SiteConfig.py
@@ -418,7 +418,7 @@ class SiteConfig():
                 x = y = z = 0
                 version_x_y = "{}.{}".format(x, y)
                 version_x_y_z = "{}.{}.{}".format(x, y, z)
-                version = data['version']
+                version = str(data['version'])
                 version_list = version.split(".")
                 try:
                     x = version_list[0].split("-")[0]


### PR DESCRIPTION
## Summary and Scope

The product version should be considered as string to use the split function. version x.y.z is taken as a string but if the version only has major and minor like x.y , python takes it as float causing split function to raise an Exception as seen in the Jira.

In this fix, the version is just explicitly being converted to string before doing a split.

## Issues and Related PRs

* Resolves [CASMTRIAGE-8020](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8020)

## Testing

Tested using a python script outside iuf-cli

SPIRA- https://spiraplan-pro-ext.it.hpe.com/SpiraPlan/3714/TestCase/List.aspx

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

