### PR TITLE
CASMTRIAGE:8500: cli gives up following pod logs

### DIFF
--- a/lib/PodLogs.py
+++ b/lib/PodLogs.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -44,9 +44,9 @@ MAX_RECORDS = 10000
 # After the processes are finished, wait for 5 minutes for any lingering pods.
 WAIT_FOR_PODS = 5 * 60 # 5 minutes
 
-# Poll the logs for 20 minutes.  It can take a while for the pods to be
+# Poll the logs for 40 minutes.  It can take a while for the pods to be
 # scheduled.
-POLL_LOGS = 20 * 60 # 20 minutes
+POLL_LOGS = 40 * 60 # 40 minutes
 
 def generate_query(pod, container="", namespace=""):
     print(f"(generate_query)pod={pod}")


### PR DESCRIPTION
## Summary and Scope

In case of an exception cli gives up following pod logs after 20 mins. This PR is increasing that time to 40 mins.

## Issues and Related PRs

* Resolves [CASMTRIAGE-8500](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8500)

## Risks and Mitigations

No

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

