### PR TITLE
CASMINST-6636 :error log info on screen

### DIFF
--- a/lib/Activity.py
+++ b/lib/Activity.py
@@ -892,7 +892,7 @@ class Activity():
                                     logdir=self.config.args.get("log_dir")
                                     file_name = s3.split("/")[-2]
                                     if dname_s3 not in printed_s3:
-                                        self.config.logger.debug(f"{log_prefix} LOG FILE FOR {dname}: {logdir}/{timestamp}/argo_logs/{file_name}-main.txt")
+                                        self.config.logger.info(f"{log_prefix} LOG FILE FOR {dname}: {logdir}/{timestamp}/argo_logs/{file_name}-main.txt")
                                         printed_s3[dname_s3] = True
                         except:
                             pass


### PR DESCRIPTION
## Summary and Scope

The name of log-file was a debug message and was not visible on the screen resulting the admin to navigate in install.log and get the filename. 
Making this as an "INFO" message as asked in JIRA to make it visible in cli output.

## Issues and Related PRs

* Resolves [CASMINST-6636](https://jira-pro.it.hpe.com:8443/browse/CASMINST-6636)

## Risks and Mitigations

No

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

