### PR TITLE
CASMINST-7090:adding activity removal

### DIFF
--- a/iuf.py
+++ b/iuf.py
@@ -422,6 +422,50 @@ def process_list_activity(config):
     else:
         print("No Activities found")
 
+def process_delete_activity(config):
+    activity_name = config.args.get("activity_name")
+    # Validate activity name is not empty
+    if not activity_name or not activity_name.strip():
+        print("ERROR: Activity name cannot be empty")
+        sys.exit(1)
+    
+    # Validate activity name format (same as other commands)
+    if not lib.Activity.valid_activity_name(activity_name):
+        print(f"ERROR: Activity name '{activity_name}' is invalid")
+        sys.exit(1)
+    
+    # Display warning and confirmation prompt
+    print("This will delete all activity metadata and log files.")
+    print("\nIMPORTANT: Ensure no IUF commands are currently running for this activity.")
+    print("This action cannot be undone.\n")
+
+    # Get user confirmation
+    invalid_count = 0
+    while True:
+        try:
+            response = input(f"Permanently delete activity '{activity_name}'. Do you want to continue? (y/n/exit): ").strip().lower()
+            if response in ['yes', 'y']:
+                break
+            elif response in ['no', 'n', 'exit']:
+                print(f"{activity_name} deletion cancelled.")
+                return
+            else:
+                invalid_count += 1
+                if invalid_count >= 3:
+                    print("ERROR: Too many invalid inputs. Cancelling deletion.")
+                    return
+                print("Invalid input. Please enter 'y', 'n', or 'exit'.")
+        except KeyboardInterrupt:
+            print(f"{activity_name} deletion cancelled.")
+            return
+    
+    # Proceed with deletion
+    try:
+        success, message = lib.Activity.delete_activity(activity_name)
+        print(f"STATUS {activity_name}: {message}'")
+    except Exception as e:
+        print(f"ERROR: Unexpected error deleting activity: {e}")
+        sys.exit(1)
 
 def process_workflow(config):
 
@@ -646,7 +690,7 @@ def main():
     # are fully independent; for example, we have an unpack stage, and an
     # install stage.  The install stage needs to install what was unpacked.
 
-    subparsers = parser.add_subparsers(title="subcommands", metavar='{run,activity,list-stages|ls,resume,restart,abort,list-activities|la,workflow}')
+    subparsers = parser.add_subparsers(title="subcommands", metavar='{run,activity,list-stages|ls,resume,restart,abort,list-activities|la,delete-activity|da,workflow}')
     stage_list = lib.stages.get_stage_help()
 
     run_sp = subparsers.add_parser("run", description='Run IUF stages to execute install, upgrade and/or deploy operations for a given activity.',
@@ -788,6 +832,11 @@ def main():
     list_activity_sp = subparsers.add_parser("list-activities",
         description="List all IUF activities stored in argo.", aliases=["la"])
     list_activity_sp.set_defaults(func=process_list_activity)
+
+    delete_activity_sp = subparsers.add_parser("delete-activity",
+        description="Delete an activity along with its metadata and logs.", aliases=["da"])
+    delete_activity_sp.add_argument("activity_name", help="Name of the activity to delete")
+    delete_activity_sp.set_defaults(func=process_delete_activity)
 
     workflow_sp = subparsers.add_parser("workflow", description="List workflows or information for a particular workflow")
     workflow_sp.add_argument("workflows", action="store", help="workflow to look up", nargs="*")

--- a/lib/Activity.py
+++ b/lib/Activity.py
@@ -38,6 +38,7 @@ import multiprocessing
 import tarfile
 import textwrap
 import time
+import subprocess
 import yaml
 from datetime import timedelta
 
@@ -99,7 +100,51 @@ def list_activity():
    
     return "\n".join(act_list)
 
+def delete_activity(activity_name):
+    """ Delete an activity with all cluster resources including log files."""
 
+    api = lib.ApiInterface.ApiInterface()
+    try:
+        response = api.delete_activity(activity_name)
+        # Check if the response was successful (status code 200)
+        if response.status_code == 200:
+            response_data = response.json()
+            # Delete log folder locally after successful backend deletion
+            log_path = f"/etc/cray/upgrade/csm/iuf/{activity_name}"
+            log_deletion_message = ""
+            
+            try:
+                if os.path.exists(log_path):
+                    shutil.rmtree(log_path)
+                    log_deletion_message = f"Deleted log folder: {log_path}"
+                else:
+                    log_deletion_message = f"Log folder {log_path} does not exist"
+            except Exception:
+                log_deletion_message = f"Warning: Could not delete log folder {log_path}. Manual cleanup required: sudo rm -rf {log_path}"
+            
+            backend_message = response_data.get("message", "Activity deleted successfully")
+            emit_message = f"{backend_message}\n{log_deletion_message}"
+            
+            return True, emit_message
+        else:
+            # Backend returned an error
+            error_msg = f"Failed to delete activity {activity_name}."
+            if response.text:
+                try:
+                    error_data = response.json()
+                    error_msg = error_data.get("message", response.text)
+                except (json.JSONDecodeError, ValueError):
+                    error_msg = response.text
+            else:
+                error_msg = f"Failed to delete activity {activity_name}. Status code: {response.status_code}"
+
+            raise ActivityError(error_msg)
+            
+    except ActivityError:
+        raise  # Re-raise ActivityError as-is
+    except Exception:
+        raise ActivityError(f"Unexpected error deleting activity {activity_name}")
+    
 class Activity():
     config = None
     states = None

--- a/lib/ApiInterface.py
+++ b/lib/ApiInterface.py
@@ -88,6 +88,15 @@ class ApiInterface(object):
         except Exception as ex:
             raise
 
+    def delete_activity(self, activity):
+        api_path = f"/activities/{activity}"
+        
+        try:
+            api_response = self.request("DELETE", api_path)
+            return api_response
+        except Exception as ex:
+            raise
+
     def post_resume(self, activity, payload):
         api_path = f"/activities/{activity}/history/resume"
         try:

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -23,9 +23,10 @@
 #
 
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch, Mock
+import os
 
-from lib.Activity import Activity
+from lib.Activity import Activity, delete_activity, ActivityError
 from lib.SiteConfig import SiteConfig
 
 
@@ -52,6 +53,122 @@ class ActivityBootprepCommandsTest(unittest.TestCase):
         )
         self.assertEqual(expected, Activity.bootprep_commands.__get__(self.mock_activity))
 
+class DeleteActivityTest(unittest.TestCase):
+    """Tests for the delete_activity function"""
+
+    @patch('lib.Activity.shutil.rmtree')
+    @patch('lib.Activity.os.path.exists')
+    @patch('lib.ApiInterface.ApiInterface')
+    def test_delete_activity_success_with_logs(self, mock_api_class, mock_exists, mock_rmtree):
+        """Test successful deletion with log folder present"""
+        mock_api = Mock()
+        mock_api_class.return_value = mock_api
+        
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"message": "Activity deleted from backend"}
+        mock_api.delete_activity.return_value = mock_response
+        
+        mock_exists.return_value = True
+        
+        success, message = delete_activity("test-activity")
+        
+        self.assertTrue(success)
+        self.assertIn("Activity deleted from backend", message)
+        self.assertIn("Deleted log folder", message)
+        mock_api.delete_activity.assert_called_once_with("test-activity")
+        mock_rmtree.assert_called_once_with("/etc/cray/upgrade/csm/iuf/test-activity")
+
+    @patch('lib.Activity.shutil.rmtree')
+    @patch('lib.Activity.os.path.exists')
+    @patch('lib.ApiInterface.ApiInterface')
+    def test_delete_activity_success_no_log_folder(self, mock_api_class, mock_exists, mock_rmtree):
+        """Test successful deletion when log folder doesn't exist"""
+        mock_api = Mock()
+        mock_api_class.return_value = mock_api
+        
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"message": "Activity deleted"}
+        mock_api.delete_activity.return_value = mock_response
+        
+        mock_exists.return_value = False
+        
+        success, message = delete_activity("test-activity")
+        
+        self.assertTrue(success)
+        self.assertIn("does not exist", message)
+        mock_rmtree.assert_not_called()
+
+    @patch('lib.Activity.shutil.rmtree')
+    @patch('lib.Activity.os.path.exists')
+    @patch('lib.ApiInterface.ApiInterface')
+    def test_delete_activity_log_deletion_fails(self, mock_api_class, mock_exists, mock_rmtree):
+        """Test deletion when log folder removal fails with any exception"""
+        mock_api = Mock()
+        mock_api_class.return_value = mock_api
+        
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"message": "Activity deleted"}
+        mock_api.delete_activity.return_value = mock_response
+        
+        mock_exists.return_value = True
+        mock_rmtree.side_effect = OSError("Disk error")
+        
+        success, message = delete_activity("test-activity")
+        
+        self.assertTrue(success)
+        self.assertIn("Warning", message)
+        self.assertIn("Manual cleanup required", message)
+        self.assertIn("sudo rm -rf", message)
+
+    @patch('lib.ApiInterface.ApiInterface')
+    def test_delete_activity_backend_returns_error(self, mock_api_class):
+        """Test deletion when backend returns non-200 status"""
+        mock_api = Mock()
+        mock_api_class.return_value = mock_api
+        
+        mock_response = Mock()
+        mock_response.status_code = 500
+        mock_response.text = "Internal server error"
+        mock_response.json.return_value = {"message": "Backend error occurred"}
+        mock_api.delete_activity.return_value = mock_response
+        
+        with self.assertRaises(ActivityError) as context:
+            delete_activity("test-activity")
+        
+        self.assertIn("Backend error occurred", str(context.exception))
+
+    @patch('lib.ApiInterface.ApiInterface')
+    def test_delete_activity_backend_raises_exception(self, mock_api_class):
+        """Test deletion when API call raises an exception"""
+        mock_api = Mock()
+        mock_api_class.return_value = mock_api
+        mock_api.delete_activity.side_effect = ConnectionError("Network error")
+        
+        with self.assertRaises(ActivityError) as context:
+            delete_activity("test-activity")
+        
+        error_msg = str(context.exception)
+        self.assertIn("test-activity", error_msg)
+
+    @patch('lib.ApiInterface.ApiInterface')
+    def test_delete_activity_backend_returns_404(self, mock_api_class):
+        """Test deletion of non-existent activity"""
+        mock_api = Mock()
+        mock_api_class.return_value = mock_api
+        
+        mock_response = Mock()
+        mock_response.status_code = 404
+        mock_response.text = "Activity not found"
+        mock_response.json.return_value = {"message": "Activity not found"}
+        mock_api.delete_activity.return_value = mock_response
+        
+        with self.assertRaises(ActivityError) as context:
+            delete_activity("non-existent-activity")
+        
+        self.assertIn("Activity not found", str(context.exception))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary and Scope

This PR introduces delete command for an activity. 

## Changes
- Added `delete` sub parser for activity
- Added delete function in Activity.py
- Added flags for confirmation, force delete, etc.
- Integrated with backend DELETE endpoint


## Issues and Related PRs

* Resolves [CASMINST-7090](https://jira-pro.it.hpe.com:8443/browse/CASMINST-7090)
* https://github.com/Cray-HPE/cray-nls/pull/232

## Testing

- Tested command with various inputs
- Screenshots attached in SPIRA- https://spiraplan-pro-ext.it.hpe.com/SpiraPlan/3714/TestCase/List.aspx

### Tested on:

  * drax

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

